### PR TITLE
fix: subsequent dsp expander device information would fail to parse if a previous device reports a fault

### DIFF
--- a/Tesira-DSP-EPI/TesiraExpanderTracker.cs
+++ b/Tesira-DSP-EPI/TesiraExpanderTracker.cs
@@ -147,7 +147,7 @@ namespace Tesira_DSP_EPI
 
                 var newData = Expanders.FirstOrDefault(o => String.Equals(o.Hostname, hostname, StringComparison.CurrentCultureIgnoreCase));
 
-                if (newData == null) return;
+				if (newData == null) continue;
                 Debug.Console(2, this, "Found a device Index {0} with Hostname {1}", newData.Index, newData.Hostname);
 
                 newData.SetData(matches[v].ToString());


### PR DESCRIPTION
Choose to "continue" instead of "return"