### PR TITLE
fix: typo in README Switcher Example

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,7 +244,7 @@ None
         "label" : "switcher01",
         "index1" : 1
         "switcherInstanceTag" : "SourceSelector1",
-        "type:": "router",
+        "type": "router",
         "bridgeIndex" : 1,
         "switcherInputs" : {
             "1" : {"label": "Input1" },


### PR DESCRIPTION
@TrevorPayne cause sometimes you just have to remove a colon