### PR TITLE
Feature/expose rawlevel on bridge

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,9 +152,10 @@ Within the **Standalone** object, this join map represents a single control as d
 
 #### Serials
 
-| Legacy Join | Standalone Join | Type (RW) | Description                      |
-| ----------- | --------------- | --------- | -------------------------------- |
-| 200         | 1               | R         | Control Label (Pass From Config) |
+| Legacy Join | Standalone Join | Type (RW) | Description                                      |
+| ----------- | --------------- | --------- | ------------------------------------------------ |
+| 200         | 1               | R         | Control Label (Pass From Config)                 |
+| 300         | 2               | R         | Raw Level in dB (e.g., "-12 dB", "-50 dB")      |
 
 #### Config Example
 

--- a/src/Bridge/JoinMaps/TesiraFaderJoinMapAdvanced.cs
+++ b/src/Bridge/JoinMaps/TesiraFaderJoinMapAdvanced.cs
@@ -118,6 +118,16 @@ namespace Pepperdash.Essentials.Plugins.DSP.Biamp.Tesira.Bridge.JoinMaps
               JoinType = eJoinType.Serial
             });
 
+    [JoinName("RawLevel")]
+    public JoinDataComplete RawLevel =
+        new JoinDataComplete(new JoinData { JoinNumber = 300, JoinSpan = 1 },
+            new JoinMetadata
+            {
+              Description = "Fader Raw Level with dB suffix",
+              JoinCapabilities = eJoinCapabilities.ToSIMPL,
+              JoinType = eJoinType.Serial
+            });
+
     public TesiraFaderJoinMapAdvanced(uint joinStart)
         : base(joinStart, typeof(TesiraFaderJoinMapAdvanced))
     {

--- a/src/TesiraDsp.cs
+++ b/src/TesiraDsp.cs
@@ -1752,6 +1752,7 @@ namespace Pepperdash.Essentials.Plugins.DSP.Biamp.Tesira
                 this.LogVerbose("TesiraChannel {0} Is Enabled", x);
 
                 channel.NameFeedback.LinkInputSig(trilist.StringInput[faderJoinMap.Label.JoinNumber + x]);
+                channel.RawLevelFeedback.LinkInputSig(trilist.StringInput[faderJoinMap.RawLevel.JoinNumber + x]);
                 channel.TypeFeedback.LinkInputSig(trilist.UShortInput[faderJoinMap.Type.JoinNumber + x]);
                 channel.ControlTypeFeedback.LinkInputSig(trilist.UShortInput[faderJoinMap.Status.JoinNumber + x]);
                 channel.PermissionsFeedback.LinkInputSig(trilist.UShortInput[faderJoinMap.Permissions.JoinNumber + x]);

--- a/src/TesiraDspFaderControl.cs
+++ b/src/TesiraDspFaderControl.cs
@@ -57,6 +57,7 @@ namespace Pepperdash.Essentials.Plugins.DSP.Biamp.Tesira
         public BoolFeedback MuteFeedback { get; private set; }
         public BoolFeedback VisibleFeedback { get; private set; }
         public IntFeedback VolumeLevelFeedback { get; private set; }
+        public StringFeedback RawLevelFeedback { get; private set; }
         public IntFeedback TypeFeedback { get; private set; }
         public IntFeedback ControlTypeFeedback { get; private set; }
         public IntFeedback PermissionsFeedback { get; private set; }
@@ -122,7 +123,16 @@ namespace Pepperdash.Essentials.Plugins.DSP.Biamp.Tesira
         /// </summary>
         public bool HasLevel { get; private set; }
 
-        public int RawVolumeLevel { get; private set; }
+        private int rawVolumeLevel;
+        public int RawVolumeLevel
+        {
+            get { return rawVolumeLevel; }
+            private set
+            {
+                rawVolumeLevel = value;
+                RawLevelFeedback.FireUpdate();
+            }
+        }
 
         public eVolumeLevelUnits Units
         {
@@ -219,12 +229,14 @@ namespace Pepperdash.Essentials.Plugins.DSP.Biamp.Tesira
             VisibleFeedback = new BoolFeedback(Key + "-VisibleFeedback", () => Enabled);
 
             VolumeLevelFeedback = new IntFeedback(Key + "-LevelFeedback", () => VolumeLevel);
+            RawLevelFeedback = new StringFeedback(Key + "-RawLevelFeedback", () => RawVolumeLevel + " dB");
             TypeFeedback = new IntFeedback(Key + "-TypeFeedback", () => (ushort)type);
             ControlTypeFeedback = new IntFeedback(Key + "-ControlTypeFeedback", () => ControlType);
             PermissionsFeedback = new IntFeedback(Key + "-PermissionsFeedback", () => Permissions);
 
             Feedbacks.Add(MuteFeedback);
             Feedbacks.Add(VolumeLevelFeedback);
+            Feedbacks.Add(RawLevelFeedback);
             Feedbacks.Add(NameFeedback);
             Feedbacks.Add(VisibleFeedback);
             Feedbacks.Add(TypeFeedback);


### PR DESCRIPTION
This pull request adds support for exposing and linking the raw fader level (with a dB suffix) throughout the Tesira DSP fader control code. The main changes involve adding a new feedback property for the raw level, updating the join map, and ensuring the value is kept up to date and linked to the API.

**Raw Level Feedback Integration:**

- Added a new `RawLevel` join to `TesiraFaderJoinMapAdvanced`, including metadata and description for use in SIMPL integration.
- Introduced a new `RawLevelFeedback` property (of type `StringFeedback`) to `TesiraDspFaderControl`, exposing the raw volume level as a string with a "dB" suffix. [[1]](diffhunk://#diff-99db1d2b8ee4f63d0f305352f9406382cd16d06fd5d3acd3320d34d1ff9be510R60) [[2]](diffhunk://#diff-99db1d2b8ee4f63d0f305352f9406382cd16d06fd5d3acd3320d34d1ff9be510R232-R239)
- Updated the `RawVolumeLevel` property to trigger `RawLevelFeedback` updates whenever its value changes, ensuring the feedback remains current.

**API and Feedback Linking:**

- Linked the new `RawLevelFeedback` signal to the appropriate join in the API layer within `LinkFadersToApi`, so external systems can receive the raw level value.
- Registered `RawLevelFeedback` in the feedbacks collection to ensure it is managed and updated alongside other feedbacks.
This pull request adds support for exposing the raw fader level in dB as a serial join and feedback property throughout the Tesira DSP fader control system. The changes ensure that the raw level (with dB suffix) is available in the API, join map, and feedback mechanisms, and are documented accordingly.

**API and Feedback Enhancements:**

* Added a new `RawLevelFeedback` property of type `StringFeedback` to `TesiraDspFaderControl`, which reports the raw volume level with a "dB" suffix and fires updates when the value changes. [[1]](diffhunk://#diff-99db1d2b8ee4f63d0f305352f9406382cd16d06fd5d3acd3320d34d1ff9be510R60) [[2]](diffhunk://#diff-99db1d2b8ee4f63d0f305352f9406382cd16d06fd5d3acd3320d34d1ff9be510L125-R135) [[3]](diffhunk://#diff-99db1d2b8ee4f63d0f305352f9406382cd16d06fd5d3acd3320d34d1ff9be510R232-R239)

**Join Map and Linking Updates:**

* Introduced a new serial join (`RawLevel`, join number 300) in `TesiraFaderJoinMapAdvanced` to represent the raw fader level in dB, including appropriate metadata and join capabilities.
* Linked the new `RawLevelFeedback` to the corresponding serial join in the `LinkFadersToApi` method, ensuring the feedback is sent to the API.

**Documentation:**

* Updated the `README.md` to document the new serial join for raw level, including its join number and description.