### PR TITLE
Fix/prevent level runaway - Closes Issue #135

### DIFF
--- a/src/TesiraDsp.cs
+++ b/src/TesiraDsp.cs
@@ -307,6 +307,7 @@ namespace Pepperdash.Essentials.Plugins.DSP.Biamp.Tesira
 
             // Stop subscription thread
             StopSubscriptionThread();
+            StopLevelRangePollTimer();
 
             if (watchDogTimer != null)
             {

--- a/src/TesiraDsp.cs
+++ b/src/TesiraDsp.cs
@@ -332,7 +332,14 @@ namespace Pepperdash.Essentials.Plugins.DSP.Biamp.Tesira
                 ? props.ResubscribeString
                 : "resubscribeAll";
 
-            levelRangePollIntervalMs = props.LevelRangePollIntervalMs;
+            // Convert seconds to ms; 0 = disabled, anything 1-59 is clamped to the 60s minimum
+            var pollSecs = props.LevelRangePollIntervalSecs;
+            if (pollSecs > 0 && pollSecs < 60)
+            {
+                this.LogInformation("levelRangePollIntervalSecs value {secs} is below minimum of 60 — clamping to 60.", pollSecs);
+                pollSecs = 60;
+            }
+            levelRangePollIntervalMs = pollSecs * 1000;
 
             // Lock the entire control point list creation process
             lock (watchdogLock)
@@ -751,7 +758,7 @@ namespace Pepperdash.Essentials.Plugins.DSP.Biamp.Tesira
             levelRangePollTimer.AutoReset = true;
             levelRangePollTimer.Start();
 
-            this.LogDebug("Level range poll timer started at {interval}ms interval.", levelRangePollIntervalMs);
+            this.LogDebug("Level range poll timer started at {interval}s interval.", levelRangePollIntervalMs / 1000);
         }
 
         private void StopLevelRangePollTimer()

--- a/src/TesiraDsp.cs
+++ b/src/TesiraDsp.cs
@@ -86,6 +86,8 @@ namespace Pepperdash.Essentials.Plugins.DSP.Biamp.Tesira
 
         private System.Timers.Timer unsubscribeTimer;
         private System.Timers.Timer queueCheckTimer;
+        private System.Timers.Timer levelRangePollTimer;
+        private int levelRangePollIntervalMs;
 
         private Thread subscribeThread;
 
@@ -330,6 +332,8 @@ namespace Pepperdash.Essentials.Plugins.DSP.Biamp.Tesira
                 ? props.ResubscribeString
                 : "resubscribeAll";
 
+            levelRangePollIntervalMs = props.LevelRangePollIntervalMs;
+
             // Lock the entire control point list creation process
             lock (watchdogLock)
             {
@@ -416,6 +420,10 @@ namespace Pepperdash.Essentials.Plugins.DSP.Biamp.Tesira
                 this.LogVerbose("faderControlBlock Key - {0}", key);
                 var value = block.Value;
 
+                // Resolve hold timeout: per-fader override takes precedence, fall back to global
+                if (!value.VolumeHoldTimeoutMs.HasValue)
+                    value.VolumeHoldTimeoutMs = props.VolumeHoldTimeoutMs;
+
                 Faders.Add(key, new TesiraDspFaderControl(key, value, this));
                 this.LogVerbose("Added faderControlPoint {0} levelTag: {1} muteTag: {2}", key, value.LevelInstanceTag,
                     value.MuteInstanceTag);
@@ -435,6 +443,11 @@ namespace Pepperdash.Essentials.Plugins.DSP.Biamp.Tesira
             {
                 var key = roomCombiner.Key;
                 var value = roomCombiner.Value;
+
+                // Resolve hold timeout: per-block override takes precedence, fall back to global
+                if (!value.VolumeHoldTimeoutMs.HasValue)
+                    value.VolumeHoldTimeoutMs = props.VolumeHoldTimeoutMs;
+
                 RoomCombiners.Add(key, new TesiraDspRoomCombiner(key, value, this));
                 this.LogVerbose("Adding Mixer {0} InstanceTag: {1}", key, value.RoomCombinerInstanceTag);
 
@@ -713,6 +726,8 @@ namespace Pepperdash.Essentials.Plugins.DSP.Biamp.Tesira
             watchDogTimeoutTimer?.Dispose();
             watchDogTimeoutTimer = null;
 
+            StopLevelRangePollTimer();
+
             // Reset watchdog state
             lock (watchdogLock)
             {
@@ -723,6 +738,40 @@ namespace Pepperdash.Essentials.Plugins.DSP.Biamp.Tesira
             }
         }
 
+
+        private void StartLevelRangePollTimer()
+        {
+            if (levelRangePollIntervalMs <= 0) return;
+
+            levelRangePollTimer?.Stop();
+            levelRangePollTimer?.Dispose();
+
+            levelRangePollTimer = new System.Timers.Timer(levelRangePollIntervalMs);
+            levelRangePollTimer.Elapsed += (sender, e) => PollLevelRanges();
+            levelRangePollTimer.AutoReset = true;
+            levelRangePollTimer.Start();
+
+            this.LogDebug("Level range poll timer started at {interval}ms interval.", levelRangePollIntervalMs);
+        }
+
+        private void StopLevelRangePollTimer()
+        {
+            if (levelRangePollTimer == null) return;
+            levelRangePollTimer.Stop();
+            levelRangePollTimer.Dispose();
+            levelRangePollTimer = null;
+        }
+
+        private void PollLevelRanges()
+        {
+            var volumeComponents = ControlPointList.OfType<IVolumeComponent>().ToList();
+            this.LogDebug("Level range poll: queuing min/max requests for {count} volume components.", volumeComponents.Count);
+            foreach (var component in volumeComponents)
+            {
+                component.GetMinLevel();
+                component.GetMaxLevel();
+            }
+        }
 
         private void CheckWatchDog()
         {
@@ -1276,6 +1325,7 @@ namespace Pepperdash.Essentials.Plugins.DSP.Biamp.Tesira
             // Start watchdog only after all subscriptions are complete
             this.LogDebug("All subscriptions complete. Starting watchdog.");
             StartWatchDog();
+            StartLevelRangePollTimer();
         }
 
         #endregion

--- a/src/TesiraDspFaderControl.cs
+++ b/src/TesiraDspFaderControl.cs
@@ -434,14 +434,17 @@ namespace Pepperdash.Essentials.Plugins.DSP.Biamp.Tesira
                     : (ushort)clampedRaw.Scale(MinLevel, MaxLevel, 0, 65535, this);
             }
 
-            // Stop the repeat cycle without clearing the held flags — physical button is still down.
-            // The hold timeout and the eventual button release remain the authoritative cleanup.
-            this.LogDebug("Out-of-range error on {LevelControlPointTag} — stopping ramp timers.", LevelControlPointTag);
+            // Stop the active repeat timers and suppress any already-queued repeat-delay/repeat
+            // callbacks from re-arming the cycle by clearing the logical held state they check.
+            // Do not stop the hold-timeout timer here; the absolute maximum hold-time safeguard
+            // should remain available until the normal release/timeout cleanup path runs.
+            this.LogDebug("Out-of-range error on {LevelControlPointTag} — stopping ramp timers and suppressing held state.", LevelControlPointTag);
             volumeUpRepeatTimer.Stop();
             volumeUpRepeatDelayTimer.Stop();
             volumeDownRepeatTimer.Stop();
             volumeDownRepeatDelayTimer.Stop();
-            volumeHoldTimeoutTimer.Stop();
+            volUpButtonHeld = false;
+            volDownButtonHeld = false;
             volUpPressTracker = false;
             volDownPressTracker = false;
 

--- a/src/TesiraDspFaderControl.cs
+++ b/src/TesiraDspFaderControl.cs
@@ -727,8 +727,11 @@ namespace Pepperdash.Essentials.Plugins.DSP.Biamp.Tesira
                     volumeUpRepeatDelayTimer.Interval = 200;
                     volumeUpRepeatDelayTimer.Start();
                     volumeHoldTimeoutTimer.Stop();
-                    volumeHoldTimeoutTimer.Interval = VolumeHoldTimeoutMs;
-                    volumeHoldTimeoutTimer.Start();
+                    if (VolumeHoldTimeoutMs > 0)
+                    {
+                        volumeHoldTimeoutTimer.Interval = VolumeHoldTimeoutMs;
+                        volumeHoldTimeoutTimer.Start();
+                    }
                     SendFullCommand("increment", "level", IncrementAmount, 1);
                     if (!AutomaticUnmuteOnVolumeUp) return;
 

--- a/src/TesiraDspFaderControl.cs
+++ b/src/TesiraDspFaderControl.cs
@@ -428,6 +428,20 @@ namespace Pepperdash.Essentials.Plugins.DSP.Biamp.Tesira
             volumeHoldTimeoutTimer.Stop();
             volUpPressTracker = false;
             volDownPressTracker = false;
+
+            // Clamp to the boundary that was exceeded so that a step size larger than the
+            // remaining range doesn't strand the fader short of the limit.
+            var val = double.Parse(m.Groups["val"].Value);
+            if (val > MaxLevel)
+            {
+                this.LogDebug("Clamping level to MaxLevel {MaxLevel} after out-of-range increment.", MaxLevel);
+                SendFullCommand("set", "level", string.Format("{0:0.000000}", MaxLevel), 1);
+            }
+            else if (val < MinLevel)
+            {
+                this.LogDebug("Clamping level to MinLevel {MinLevel} after out-of-range decrement.", MinLevel);
+                SendFullCommand("set", "level", string.Format("{0:0.000000}", MinLevel), 1);
+            }
         }
 
 

--- a/src/TesiraDspFaderControl.cs
+++ b/src/TesiraDspFaderControl.cs
@@ -51,6 +51,7 @@ namespace Pepperdash.Essentials.Plugins.DSP.Biamp.Tesira
         private string IncrementAmount { get; set; }
         private bool UseAbsoluteValue { get; set; }
         private int VolumeRepeatRateMs { get; set; }
+        private int VolumeHoldTimeoutMs { get; set; }
         private EPdtLevelTypes type;
         private string LevelControlPointTag { get { return InstanceTag1; } }
 
@@ -69,11 +70,20 @@ namespace Pepperdash.Essentials.Plugins.DSP.Biamp.Tesira
         System.Timers.Timer volumeDownRepeatTimer;
         System.Timers.Timer volumeUpRepeatDelayTimer;
         System.Timers.Timer volumeDownRepeatDelayTimer;
+        System.Timers.Timer volumeHoldTimeoutTimer;
 
         //private bool LevelSubscribed { get; set; }
 
         bool volDownPressTracker;
         bool volUpPressTracker;
+
+        // Guards against race condition: timer callbacks can fire after Stop() if they were
+        // already queued on a thread pool thread. These flags are set true only on the
+        // initial button press and cleared synchronously on release, so an in-flight
+        // VolumeUpRepeatDelay/VolumeDownRepeatDelay callback can detect that the button
+        // was released and bail out before re-arming the repeat cycle.
+        bool volUpButtonHeld;
+        bool volDownButtonHeld;
 
 
         /// <summary>
@@ -178,6 +188,7 @@ namespace Pepperdash.Essentials.Plugins.DSP.Biamp.Tesira
             IncrementAmount = config.IncrementAmount;
             AutomaticUnmuteOnVolumeUp = config.UnmuteOnVolChange;
             VolumeRepeatRateMs = config.VolumeRepeatRateMs;
+            VolumeHoldTimeoutMs = config.VolumeHoldTimeoutMs;
             volumeUpRepeatTimer = new System.Timers.Timer();
             volumeUpRepeatTimer.Elapsed += (sender, e) => VolumeUpRepeat(null);
             volumeUpRepeatTimer.AutoReset = false;
@@ -197,6 +208,11 @@ namespace Pepperdash.Essentials.Plugins.DSP.Biamp.Tesira
             volumeDownRepeatDelayTimer.Elapsed += (sender, e) => VolumeDownRepeatDelay(null);
             volumeDownRepeatDelayTimer.AutoReset = false;
             volumeDownRepeatDelayTimer.Enabled = false;
+
+            volumeHoldTimeoutTimer = new System.Timers.Timer();
+            volumeHoldTimeoutTimer.Elapsed += (sender, e) => VolumeHoldTimeout();
+            volumeHoldTimeoutTimer.AutoReset = false;
+            volumeHoldTimeoutTimer.Enabled = false;
 
             SubscriptionTracker = new Dictionary<string, SubscriptionTrackingObject>
             {
@@ -250,24 +266,35 @@ namespace Pepperdash.Essentials.Plugins.DSP.Biamp.Tesira
 
         private void VolumeUpRepeat(object callbackObject)
         {
-            if (volUpPressTracker)
+            if (volUpPressTracker && volUpButtonHeld)
                 VolumeUp(true);
         }
         private void VolumeDownRepeat(object callbackObject)
         {
-            if (volDownPressTracker)
+            if (volDownPressTracker && volDownButtonHeld)
                 VolumeDown(true);
         }
 
         private void VolumeUpRepeatDelay(object callbackObject)
         {
+            // Button may have been released while this callback was queued on the thread pool.
+            // Check the held flag before arming the repeat cycle.
+            if (!volUpButtonHeld) return;
             volUpPressTracker = true;
             VolumeUp(true);
         }
         private void VolumeDownRepeatDelay(object callbackObject)
         {
+            if (!volDownButtonHeld) return;
             volDownPressTracker = true;
             VolumeDown(true);
+        }
+
+        private void VolumeHoldTimeout()
+        {
+            this.LogWarning("Volume hold timeout expired for {LevelControlPointTag} — forcing release. Panel may have dropped.", LevelControlPointTag);
+            VolumeUp(false);
+            VolumeDown(false);
         }
 
         /// <summary>
@@ -551,17 +578,23 @@ namespace Pepperdash.Essentials.Plugins.DSP.Biamp.Tesira
                 }
                 else if (!volDownPressTracker)
                 {
+                    volDownButtonHeld = true;
                     volumeDownRepeatDelayTimer.Stop();
                     volumeDownRepeatDelayTimer.Interval = 200;
                     volumeDownRepeatDelayTimer.Start();
+                    volumeHoldTimeoutTimer.Stop();
+                    volumeHoldTimeoutTimer.Interval = VolumeHoldTimeoutMs;
+                    volumeHoldTimeoutTimer.Start();
                     SendFullCommand("decrement", "level", IncrementAmount, 1);
                 }
                 return;
             }
 
+            volDownButtonHeld = false;
             volDownPressTracker = false;
             volumeDownRepeatTimer.Stop();
             volumeDownRepeatDelayTimer.Stop();
+            volumeHoldTimeoutTimer.Stop();
         }
 
         /// <summary>
@@ -584,9 +617,13 @@ namespace Pepperdash.Essentials.Plugins.DSP.Biamp.Tesira
                 }
                 else if (!volUpPressTracker)
                 {
+                    volUpButtonHeld = true;
                     volumeUpRepeatDelayTimer.Stop();
                     volumeUpRepeatDelayTimer.Interval = 200;
                     volumeUpRepeatDelayTimer.Start();
+                    volumeHoldTimeoutTimer.Stop();
+                    volumeHoldTimeoutTimer.Interval = VolumeHoldTimeoutMs;
+                    volumeHoldTimeoutTimer.Start();
                     SendFullCommand("increment", "level", IncrementAmount, 1);
                     if (!AutomaticUnmuteOnVolumeUp) return;
 
@@ -598,9 +635,11 @@ namespace Pepperdash.Essentials.Plugins.DSP.Biamp.Tesira
                 return;
             }
 
+            volUpButtonHeld = false;
             volUpPressTracker = false;
             volumeUpRepeatTimer.Stop();
             volumeUpRepeatDelayTimer.Stop();
+            volumeHoldTimeoutTimer.Stop();
         }
 
 
@@ -659,7 +698,13 @@ namespace Pepperdash.Essentials.Plugins.DSP.Biamp.Tesira
 
             trilist.OnlineStatusChange += (d, args) =>
             {
-                if (!args.DeviceOnLine) return;
+                if (!args.DeviceOnLine)
+                {
+                    // Panel dropped — force release of any held volume button to prevent runaway
+                    VolumeUp(false);
+                    VolumeDown(false);
+                    return;
+                }
 
                 foreach (var feedback in Feedbacks)
                 {

--- a/src/TesiraDspFaderControl.cs
+++ b/src/TesiraDspFaderControl.cs
@@ -368,7 +368,22 @@ namespace Pepperdash.Essentials.Plugins.DSP.Biamp.Tesira
 
                 RawVolumeLevel = (int)localValue;
 
-                VolumeLevel = UseAbsoluteValue ? (ushort)localValue : (ushort)localValue.Scale(MinLevel, MaxLevel, 0, 65535, this);
+                if (!UseAbsoluteValue && (localValue < MinLevel || localValue > MaxLevel))
+                {
+                    // Value is outside our known range — the DSP range likely changed externally.
+                    // Clamp to boundary so the ushort cast doesn't wrap, then re-poll to get the new range.
+                    this.LogInformation(
+                        "Level {val} dB outside known range [{min},{max}] — clamping feedback and re-polling min/max.",
+                        localValue, MinLevel, MaxLevel);
+                    var clamped = Math.Max(MinLevel, Math.Min(MaxLevel, localValue));
+                    VolumeLevel = (ushort)clamped.Scale(MinLevel, MaxLevel, 0, 65535, this);
+                    GetMinLevel();
+                    GetMaxLevel();
+                }
+                else
+                {
+                    VolumeLevel = UseAbsoluteValue ? (ushort)localValue : (ushort)localValue.Scale(MinLevel, MaxLevel, 0, 65535, this);
+                }
 
                 SubscriptionTracker["level"].Subscribed = true;
             }
@@ -409,13 +424,14 @@ namespace Pepperdash.Essentials.Plugins.DSP.Biamp.Tesira
 
             if (rangeChanged)
             {
-                // Rescale using the val reported in the error — most accurate since it reflects
-                // what the DSP has at this moment, regardless of subscription lag.
+                // val is the attempted (out-of-range) level, not the actual DSP level.
+                // Clamp it to the new boundary before scaling to prevent ushort wrap.
                 var currentRaw = double.Parse(m.Groups["val"].Value);
-                RawVolumeLevel = (int)currentRaw;
+                var clampedRaw = Math.Max(MinLevel, Math.Min(MaxLevel, currentRaw));
+                RawVolumeLevel = (int)clampedRaw;
                 VolumeLevel = UseAbsoluteValue
-                    ? (ushort)currentRaw
-                    : (ushort)currentRaw.Scale(MinLevel, MaxLevel, 0, 65535, this);
+                    ? (ushort)clampedRaw
+                    : (ushort)clampedRaw.Scale(MinLevel, MaxLevel, 0, 65535, this);
             }
 
             // Stop the repeat cycle without clearing the held flags — physical button is still down.
@@ -477,17 +493,17 @@ namespace Pepperdash.Essentials.Plugins.DSP.Biamp.Tesira
                     case "minLevel":
                         {
                             MinLevel = double.Parse(value);
-
                             this.LogDebug("MinLevel is '{MinLevel}'", MinLevel);
-
+                            if (!UseAbsoluteValue)
+                                VolumeLevel = (ushort)((double)RawVolumeLevel).Scale(MinLevel, MaxLevel, 0, 65535, this);
                             break;
                         }
                     case "maxLevel":
                         {
                             MaxLevel = double.Parse(value);
-
                             this.LogDebug("MaxLevel is '{MaxLevel}'", MaxLevel);
-
+                            if (!UseAbsoluteValue)
+                                VolumeLevel = (ushort)((double)RawVolumeLevel).Scale(MinLevel, MaxLevel, 0, 65535, this);
                             break;
                         }
                     case "level":

--- a/src/TesiraDspFaderControl.cs
+++ b/src/TesiraDspFaderControl.cs
@@ -474,8 +474,12 @@ namespace Pepperdash.Essentials.Plugins.DSP.Biamp.Tesira
 
                 if (message.IndexOf("-ERR INVALID_PARAMETER", StringComparison.Ordinal) >= 0)
                 {
-                    HandleOutOfRangeError(message);
-                    return;
+                    var isOutOfRangeError = Regex.IsMatch(message, @"\bout of range\b", RegexOptions.IgnoreCase);
+                    if (isOutOfRangeError)
+                    {
+                        HandleOutOfRangeError(message);
+                        return;
+                    }
                 }
 
                 // Parse an "+OK" message

--- a/src/TesiraDspFaderControl.cs
+++ b/src/TesiraDspFaderControl.cs
@@ -502,7 +502,10 @@ namespace Pepperdash.Essentials.Plugins.DSP.Biamp.Tesira
                             MinLevel = double.Parse(value);
                             this.LogDebug("MinLevel is '{MinLevel}'", MinLevel);
                             if (!UseAbsoluteValue)
-                                VolumeLevel = (ushort)((double)RawVolumeLevel).Scale(MinLevel, MaxLevel, 0, 65535, this);
+                            {
+                                var clampedRawLevel = Math.Max(MinLevel, Math.Min(MaxLevel, (double)RawVolumeLevel));
+                                VolumeLevel = (ushort)clampedRawLevel.Scale(MinLevel, MaxLevel, 0, 65535, this);
+                            }
                             break;
                         }
                     case "maxLevel":
@@ -510,7 +513,10 @@ namespace Pepperdash.Essentials.Plugins.DSP.Biamp.Tesira
                             MaxLevel = double.Parse(value);
                             this.LogDebug("MaxLevel is '{MaxLevel}'", MaxLevel);
                             if (!UseAbsoluteValue)
-                                VolumeLevel = (ushort)((double)RawVolumeLevel).Scale(MinLevel, MaxLevel, 0, 65535, this);
+                            {
+                                var clampedRawLevel = Math.Max(MinLevel, Math.Min(MaxLevel, (double)RawVolumeLevel));
+                                VolumeLevel = (ushort)clampedRawLevel.Scale(MinLevel, MaxLevel, 0, 65535, this);
+                            }
                             break;
                         }
                     case "level":

--- a/src/TesiraDspFaderControl.cs
+++ b/src/TesiraDspFaderControl.cs
@@ -188,7 +188,7 @@ namespace Pepperdash.Essentials.Plugins.DSP.Biamp.Tesira
             IncrementAmount = config.IncrementAmount;
             AutomaticUnmuteOnVolumeUp = config.UnmuteOnVolChange;
             VolumeRepeatRateMs = config.VolumeRepeatRateMs;
-            VolumeHoldTimeoutMs = config.VolumeHoldTimeoutMs;
+            VolumeHoldTimeoutMs = config.VolumeHoldTimeoutMs ?? 10000;
             volumeUpRepeatTimer = new System.Timers.Timer();
             volumeUpRepeatTimer.Elapsed += (sender, e) => VolumeUpRepeat(null);
             volumeUpRepeatTimer.AutoReset = false;

--- a/src/TesiraDspFaderControl.cs
+++ b/src/TesiraDspFaderControl.cs
@@ -378,6 +378,58 @@ namespace Pepperdash.Essentials.Plugins.DSP.Biamp.Tesira
         const string parsePattern = "[^ ]* (.*)";
         private readonly static Regex parseRegex = new Regex(parsePattern);
 
+        // Matches: -ERR INVALID_PARAMETER Value out of range: attr:level min:-45 max:-5 val:-3
+        private readonly static Regex outOfRangeRegex = new Regex(
+            @"-ERR INVALID_PARAMETER Value out of range: attr:\S+ min:(?<min>[\d.\-]+) max:(?<max>[\d.\-]+) val:(?<val>[\d.\-]+)",
+            RegexOptions.Compiled);
+
+        private void HandleOutOfRangeError(string message)
+        {
+            var m = outOfRangeRegex.Match(message);
+            if (!m.Success) return;
+
+            var reportedMin = double.Parse(m.Groups["min"].Value);
+            var reportedMax = double.Parse(m.Groups["max"].Value);
+
+            var rangeChanged = false;
+
+            if (Math.Abs(reportedMin - MinLevel) > 0.001)
+            {
+                this.LogInformation("MinLevel updated by DSP error response: {old} -> {new}", MinLevel, reportedMin);
+                MinLevel = reportedMin;
+                rangeChanged = true;
+            }
+
+            if (Math.Abs(reportedMax - MaxLevel) > 0.001)
+            {
+                this.LogInformation("MaxLevel updated by DSP error response: {old} -> {new}", MaxLevel, reportedMax);
+                MaxLevel = reportedMax;
+                rangeChanged = true;
+            }
+
+            if (rangeChanged)
+            {
+                // Rescale using the val reported in the error — most accurate since it reflects
+                // what the DSP has at this moment, regardless of subscription lag.
+                var currentRaw = double.Parse(m.Groups["val"].Value);
+                RawVolumeLevel = (int)currentRaw;
+                VolumeLevel = UseAbsoluteValue
+                    ? (ushort)currentRaw
+                    : (ushort)currentRaw.Scale(MinLevel, MaxLevel, 0, 65535, this);
+            }
+
+            // Stop the repeat cycle without clearing the held flags — physical button is still down.
+            // The hold timeout and the eventual button release remain the authoritative cleanup.
+            this.LogDebug("Out-of-range error on {LevelControlPointTag} — stopping ramp timers.", LevelControlPointTag);
+            volumeUpRepeatTimer.Stop();
+            volumeUpRepeatDelayTimer.Stop();
+            volumeDownRepeatTimer.Stop();
+            volumeDownRepeatDelayTimer.Stop();
+            volumeHoldTimeoutTimer.Stop();
+            volUpPressTracker = false;
+            volDownPressTracker = false;
+        }
+
 
         /// <summary>
         /// Parses non-subscription response data for the component
@@ -389,6 +441,13 @@ namespace Pepperdash.Essentials.Plugins.DSP.Biamp.Tesira
             try
             {
                 this.LogVerbose("Parsing Message - {message}. AttributeCode: {attributeCode}", message, attributeCode);
+
+                if (message.IndexOf("-ERR INVALID_PARAMETER", StringComparison.Ordinal) >= 0)
+                {
+                    HandleOutOfRangeError(message);
+                    return;
+                }
+
                 // Parse an "+OK" message
 
                 var match = parseRegex.Match(message);

--- a/src/TesiraDspFaderControl.cs
+++ b/src/TesiraDspFaderControl.cs
@@ -685,8 +685,11 @@ namespace Pepperdash.Essentials.Plugins.DSP.Biamp.Tesira
                     volumeDownRepeatDelayTimer.Interval = 200;
                     volumeDownRepeatDelayTimer.Start();
                     volumeHoldTimeoutTimer.Stop();
-                    volumeHoldTimeoutTimer.Interval = VolumeHoldTimeoutMs;
-                    volumeHoldTimeoutTimer.Start();
+                    if (VolumeHoldTimeoutMs > 0)
+                    {
+                        volumeHoldTimeoutTimer.Interval = VolumeHoldTimeoutMs;
+                        volumeHoldTimeoutTimer.Start();
+                    }
                     SendFullCommand("decrement", "level", IncrementAmount, 1);
                 }
                 return;

--- a/src/TesiraDspFaderControl.cs
+++ b/src/TesiraDspFaderControl.cs
@@ -82,8 +82,8 @@ namespace Pepperdash.Essentials.Plugins.DSP.Biamp.Tesira
         // initial button press and cleared synchronously on release, so an in-flight
         // VolumeUpRepeatDelay/VolumeDownRepeatDelay callback can detect that the button
         // was released and bail out before re-arming the repeat cycle.
-        bool volUpButtonHeld;
-        bool volDownButtonHeld;
+        volatile bool volUpButtonHeld;
+        volatile bool volDownButtonHeld;
 
 
         /// <summary>

--- a/src/TesiraDspPropertiesConfig.cs
+++ b/src/TesiraDspPropertiesConfig.cs
@@ -54,6 +54,22 @@ namespace Pepperdash.Essentials.Plugins.DSP.Biamp.Tesira
 
         [JsonProperty("resubscribeString")]
         public string ResubscribeString { get; set; }
+
+        /// <summary>
+        /// Interval in milliseconds at which to re-poll min/max level ranges for all volume
+        /// components. Useful when an external program may change ranges at runtime.
+        /// Set to 0 (default) to disable periodic polling.
+        /// </summary>
+        [JsonProperty("levelRangePollIntervalMs")]
+        public int LevelRangePollIntervalMs { get; set; } = 0;
+
+        /// <summary>
+        /// Global maximum time in milliseconds a volume button may be held before the repeat
+        /// is force-released. Can be overridden per fader/room combiner via volumeHoldTimeoutMs
+        /// on the individual block config. Defaults to 10 seconds.
+        /// </summary>
+        [JsonProperty("volumeHoldTimeoutMs")]
+        public int VolumeHoldTimeoutMs { get; set; } = 10000;
     }
 
     public class TesiraExpanderBlockConfig
@@ -114,11 +130,11 @@ namespace Pepperdash.Essentials.Plugins.DSP.Biamp.Tesira
 
         /// <summary>
         /// Maximum time in milliseconds a volume button may be held before the repeat is
-        /// force-released. Guards against UI panel dropout leaving the repeat running
-        /// indefinitely. Defaults to 10 seconds.
+        /// force-released. Overrides the global volumeHoldTimeoutMs when set.
+        /// Leave unset (null) to use the global value.
         /// </summary>
         [JsonProperty("volumeHoldTimeoutMs")]
-        public int VolumeHoldTimeoutMs { get; set; } = 10000;
+        public int? VolumeHoldTimeoutMs { get; set; } = null;
     }
 
 
@@ -425,11 +441,11 @@ namespace Pepperdash.Essentials.Plugins.DSP.Biamp.Tesira
 
         /// <summary>
         /// Maximum time in milliseconds a volume button may be held before the repeat is
-        /// force-released. Guards against UI panel dropout leaving the repeat running
-        /// indefinitely. Defaults to 10 seconds.
+        /// force-released. Overrides the global volumeHoldTimeoutMs when set.
+        /// Leave unset (null) to use the global value.
         /// </summary>
         [JsonProperty("volumeHoldTimeoutMs")]
-        public int VolumeHoldTimeoutMs { get; set; } = 10000;
+        public int? VolumeHoldTimeoutMs { get; set; } = null;
     }
 
     public class RoutingPort

--- a/src/TesiraDspPropertiesConfig.cs
+++ b/src/TesiraDspPropertiesConfig.cs
@@ -56,12 +56,12 @@ namespace Pepperdash.Essentials.Plugins.DSP.Biamp.Tesira
         public string ResubscribeString { get; set; }
 
         /// <summary>
-        /// Interval in milliseconds at which to re-poll min/max level ranges for all volume
+        /// Interval in seconds at which to re-poll min/max level ranges for all volume
         /// components. Useful when an external program may change ranges at runtime.
-        /// Set to 0 (default) to disable periodic polling.
+        /// Set to 0 (default) to disable. Minimum enforced value when enabled is 60 seconds.
         /// </summary>
-        [JsonProperty("levelRangePollIntervalMs")]
-        public int LevelRangePollIntervalMs { get; set; } = 0;
+        [JsonProperty("levelRangePollIntervalSecs")]
+        public int LevelRangePollIntervalSecs { get; set; } = 0;
 
         /// <summary>
         /// Global maximum time in milliseconds a volume button may be held before the repeat

--- a/src/TesiraDspPropertiesConfig.cs
+++ b/src/TesiraDspPropertiesConfig.cs
@@ -111,6 +111,14 @@ namespace Pepperdash.Essentials.Plugins.DSP.Biamp.Tesira
 
         [JsonProperty("volumeRepeatRateMs")]
         public int VolumeRepeatRateMs { get; set; } = 100;
+
+        /// <summary>
+        /// Maximum time in milliseconds a volume button may be held before the repeat is
+        /// force-released. Guards against UI panel dropout leaving the repeat running
+        /// indefinitely. Defaults to 10 seconds.
+        /// </summary>
+        [JsonProperty("volumeHoldTimeoutMs")]
+        public int VolumeHoldTimeoutMs { get; set; } = 10000;
     }
 
 
@@ -414,6 +422,14 @@ namespace Pepperdash.Essentials.Plugins.DSP.Biamp.Tesira
 
         [JsonProperty("volumeRepeatRateMs")]
         public int VolumeRepeatRateMs { get; set; } = 250;
+
+        /// <summary>
+        /// Maximum time in milliseconds a volume button may be held before the repeat is
+        /// force-released. Guards against UI panel dropout leaving the repeat running
+        /// indefinitely. Defaults to 10 seconds.
+        /// </summary>
+        [JsonProperty("volumeHoldTimeoutMs")]
+        public int VolumeHoldTimeoutMs { get; set; } = 10000;
     }
 
     public class RoutingPort

--- a/src/TesiraDspRoomCombiner.cs
+++ b/src/TesiraDspRoomCombiner.cs
@@ -99,17 +99,27 @@ namespace Pepperdash.Essentials.Plugins.DSP.Biamp.Tesira
         private string IncrementAmount { get; set; }
         private bool UseAbsoluteValue { get; set; }
         private int VolumeRepeatRateMs { get; set; }
+        private int VolumeHoldTimeoutMs { get; set; }
         private string LevelControlPointTag { get { return InstanceTag1; } }
 
         System.Timers.Timer volumeUpRepeatTimer;
         System.Timers.Timer volumeDownRepeatTimer;
         System.Timers.Timer volumeUpRepeatDelayTimer;
         System.Timers.Timer volumeDownRepeatDelayTimer;
+        System.Timers.Timer volumeHoldTimeoutTimer;
 
         System.Timers.Timer pollTimer;
 
         bool volDownPressTracker;
         bool volUpPressTracker;
+
+        // Guards against race condition: timer callbacks can fire after Stop() if they were
+        // already queued on a thread pool thread. These flags are set true only on the
+        // initial button press and cleared synchronously on release, so an in-flight
+        // VolumeUpRepeatDelay/VolumeDownRepeatDelay callback can detect that the button
+        // was released and bail out before re-arming the repeat cycle.
+        bool volUpButtonHeld;
+        bool volDownButtonHeld;
 
         /// <summary>
         /// Subscription identifier for Room Combiner
@@ -173,6 +183,7 @@ namespace Pepperdash.Essentials.Plugins.DSP.Biamp.Tesira
             IncrementAmount = config.IncrementAmount;
             AutomaticUnmuteOnVolumeUp = config.UnmuteOnVolChange;
             VolumeRepeatRateMs = config.VolumeRepeatRateMs;
+            VolumeHoldTimeoutMs = config.VolumeHoldTimeoutMs;
             volumeUpRepeatTimer = new System.Timers.Timer();
             volumeUpRepeatTimer.Elapsed += (sender, e) => VolumeUpRepeat();
             volumeUpRepeatTimer.AutoReset = false;
@@ -192,6 +203,11 @@ namespace Pepperdash.Essentials.Plugins.DSP.Biamp.Tesira
             volumeDownRepeatDelayTimer.Elapsed += (sender, e) => VolumeDownRepeatDelay();
             volumeDownRepeatDelayTimer.AutoReset = false;
             volumeDownRepeatDelayTimer.Enabled = false;
+
+            volumeHoldTimeoutTimer = new System.Timers.Timer();
+            volumeHoldTimeoutTimer.Elapsed += (sender, e) => VolumeHoldTimeout();
+            volumeHoldTimeoutTimer.AutoReset = false;
+            volumeHoldTimeoutTimer.Enabled = false;
 
             pollTimer = new System.Timers.Timer();
             pollTimer.Elapsed += (sender, e) => DoPoll();
@@ -232,24 +248,33 @@ namespace Pepperdash.Essentials.Plugins.DSP.Biamp.Tesira
 
         private void VolumeUpRepeat()
         {
-            if (volUpPressTracker)
+            if (volUpPressTracker && volUpButtonHeld)
                 VolumeUp(true);
         }
         private void VolumeDownRepeat()
         {
-            if (volDownPressTracker)
+            if (volDownPressTracker && volDownButtonHeld)
                 VolumeDown(true);
         }
 
         private void VolumeUpRepeatDelay()
         {
+            if (!volUpButtonHeld) return;
             volUpPressTracker = true;
             VolumeUp(true);
         }
         private void VolumeDownRepeatDelay()
         {
+            if (!volDownButtonHeld) return;
             volDownPressTracker = true;
             VolumeDown(true);
+        }
+
+        private void VolumeHoldTimeout()
+        {
+            this.LogWarning("Volume hold timeout expired for {LevelControlPointTag} — forcing release. Panel may have dropped.", LevelControlPointTag);
+            VolumeUp(false);
+            VolumeDown(false);
         }
 
         /// <summary>
@@ -485,18 +510,24 @@ namespace Pepperdash.Essentials.Plugins.DSP.Biamp.Tesira
                 }
                 else if (!volDownPressTracker)
                 {
+                    volDownButtonHeld = true;
                     volumeDownRepeatDelayTimer.Stop();
                     volumeDownRepeatDelayTimer.Interval = 200;
                     volumeDownRepeatDelayTimer.Start();
+                    volumeHoldTimeoutTimer.Stop();
+                    volumeHoldTimeoutTimer.Interval = VolumeHoldTimeoutMs;
+                    volumeHoldTimeoutTimer.Start();
                     SendFullCommand("decrement", "levelOut", IncrementAmount, 1);
                 }
 
             }
             if (!press)
             {
+                volDownButtonHeld = false;
                 volDownPressTracker = false;
                 volumeDownRepeatTimer.Stop();
                 volumeDownRepeatDelayTimer.Stop();
+                volumeHoldTimeoutTimer.Stop();
             }
         }
 
@@ -519,9 +550,13 @@ namespace Pepperdash.Essentials.Plugins.DSP.Biamp.Tesira
                 }
                 else if (!volUpPressTracker)
                 {
+                    volUpButtonHeld = true;
                     volumeUpRepeatDelayTimer.Stop();
                     volumeUpRepeatDelayTimer.Interval = 200;
                     volumeUpRepeatDelayTimer.Start();
+                    volumeHoldTimeoutTimer.Stop();
+                    volumeHoldTimeoutTimer.Interval = VolumeHoldTimeoutMs;
+                    volumeHoldTimeoutTimer.Start();
                     SendFullCommand("increment", "levelOut", IncrementAmount, 1);
                     if (AutomaticUnmuteOnVolumeUp)
                     {
@@ -534,9 +569,11 @@ namespace Pepperdash.Essentials.Plugins.DSP.Biamp.Tesira
             }
             if (!press)
             {
+                volUpButtonHeld = false;
                 volUpPressTracker = false;
                 volumeUpRepeatTimer.Stop();
                 volumeUpRepeatDelayTimer.Stop();
+                volumeHoldTimeoutTimer.Stop();
             }
         }
 
@@ -595,7 +632,13 @@ namespace Pepperdash.Essentials.Plugins.DSP.Biamp.Tesira
 
             trilist.OnlineStatusChange += (d, args) =>
             {
-                if (!args.DeviceOnLine) return;
+                if (!args.DeviceOnLine)
+                {
+                    // Panel dropped — force release of any held volume button to prevent runaway
+                    VolumeUp(false);
+                    VolumeDown(false);
+                    return;
+                }
 
                 foreach (var feedback in Feedbacks)
                 {

--- a/src/TesiraDspRoomCombiner.cs
+++ b/src/TesiraDspRoomCombiner.cs
@@ -367,6 +367,20 @@ namespace Pepperdash.Essentials.Plugins.DSP.Biamp.Tesira
             volumeHoldTimeoutTimer.Stop();
             volUpPressTracker = false;
             volDownPressTracker = false;
+
+            // Clamp to the boundary that was exceeded so that a step size larger than the
+            // remaining range doesn't strand the fader short of the limit.
+            var val = double.Parse(m.Groups["val"].Value);
+            if (val > MaxLevel)
+            {
+                this.LogDebug("Clamping levelOut to MaxLevel {MaxLevel} after out-of-range increment.", MaxLevel);
+                SendFullCommand("set", "levelOut", string.Format("{0:0.000000}", MaxLevel), 1);
+            }
+            else if (val < MinLevel)
+            {
+                this.LogDebug("Clamping levelOut to MinLevel {MinLevel} after out-of-range decrement.", MinLevel);
+                SendFullCommand("set", "levelOut", string.Format("{0:0.000000}", MinLevel), 1);
+            }
         }
 
 

--- a/src/TesiraDspRoomCombiner.cs
+++ b/src/TesiraDspRoomCombiner.cs
@@ -418,8 +418,12 @@ namespace Pepperdash.Essentials.Plugins.DSP.Biamp.Tesira
 
                 if (message.IndexOf("-ERR INVALID_PARAMETER", StringComparison.Ordinal) >= 0)
                 {
-                    HandleOutOfRangeError(message);
-                    return;
+                    var isOutOfRangeError = Regex.IsMatch(message, @"\bout of range\b", RegexOptions.IgnoreCase);
+                    if (isOutOfRangeError)
+                    {
+                        HandleOutOfRangeError(message);
+                        return;
+                    }
                 }
 
                 // Parse an "+OK" message

--- a/src/TesiraDspRoomCombiner.cs
+++ b/src/TesiraDspRoomCombiner.cs
@@ -442,7 +442,10 @@ namespace Pepperdash.Essentials.Plugins.DSP.Biamp.Tesira
                             MinLevel = double.Parse(value);
                             this.LogDebug("MinLevel: {MinLevel}", MinLevel);
                             if (!UseAbsoluteValue)
-                                OutVolumeLevel = (ushort)rawOutVolumeLevelDb.Scale(MinLevel, MaxLevel, 0, 65535, this);
+                            {
+                                var clampedRawLevel = Math.Max(MinLevel, Math.Min(MaxLevel, rawOutVolumeLevelDb));
+                                OutVolumeLevel = (ushort)clampedRawLevel.Scale(MinLevel, MaxLevel, 0, 65535, this);
+                            }
                             break;
                         }
                     case "levelOutMax":
@@ -450,7 +453,10 @@ namespace Pepperdash.Essentials.Plugins.DSP.Biamp.Tesira
                             MaxLevel = double.Parse(value);
                             this.LogDebug("MaxLevel: {MaxLevel}", MaxLevel);
                             if (!UseAbsoluteValue)
-                                OutVolumeLevel = (ushort)rawOutVolumeLevelDb.Scale(MinLevel, MaxLevel, 0, 65535, this);
+                            {
+                                var clampedRawLevel = Math.Max(MinLevel, Math.Min(MaxLevel, rawOutVolumeLevelDb));
+                                OutVolumeLevel = (ushort)clampedRawLevel.Scale(MinLevel, MaxLevel, 0, 65535, this);
+                            }
                             break;
                         }
                     case "muteOut":

--- a/src/TesiraDspRoomCombiner.cs
+++ b/src/TesiraDspRoomCombiner.cs
@@ -320,6 +320,55 @@ namespace Pepperdash.Essentials.Plugins.DSP.Biamp.Tesira
         const string parsePattern = "[^ ]* (.*)";
         private readonly static Regex parseRegex = new Regex(parsePattern);
 
+        // Matches: -ERR INVALID_PARAMETER Value out of range: attr:levelOut min:-45 max:-5 val:-3
+        private readonly static Regex outOfRangeRegex = new Regex(
+            @"-ERR INVALID_PARAMETER Value out of range: attr:\S+ min:(?<min>[\d.\-]+) max:(?<max>[\d.\-]+) val:(?<val>[\d.\-]+)",
+            RegexOptions.Compiled);
+
+        private void HandleOutOfRangeError(string message)
+        {
+            var m = outOfRangeRegex.Match(message);
+            if (!m.Success) return;
+
+            var reportedMin = double.Parse(m.Groups["min"].Value);
+            var reportedMax = double.Parse(m.Groups["max"].Value);
+
+            var rangeChanged = false;
+
+            if (Math.Abs(reportedMin - MinLevel) > 0.001)
+            {
+                this.LogInformation("MinLevel updated by DSP error response: {old} -> {new}", MinLevel, reportedMin);
+                MinLevel = reportedMin;
+                rangeChanged = true;
+            }
+
+            if (Math.Abs(reportedMax - MaxLevel) > 0.001)
+            {
+                this.LogInformation("MaxLevel updated by DSP error response: {old} -> {new}", MaxLevel, reportedMax);
+                MaxLevel = reportedMax;
+                rangeChanged = true;
+            }
+
+            if (rangeChanged)
+            {
+                var currentRaw = double.Parse(m.Groups["val"].Value);
+                OutVolumeLevel = UseAbsoluteValue
+                    ? (ushort)currentRaw
+                    : (ushort)currentRaw.Scale(MinLevel, MaxLevel, 0, 65535, this);
+            }
+
+            // Stop the repeat cycle without clearing the held flags — physical button is still down.
+            // The hold timeout and the eventual button release remain the authoritative cleanup.
+            this.LogDebug("Out-of-range error on {LevelControlPointTag} — stopping ramp timers.", LevelControlPointTag);
+            volumeUpRepeatTimer.Stop();
+            volumeUpRepeatDelayTimer.Stop();
+            volumeDownRepeatTimer.Stop();
+            volumeDownRepeatDelayTimer.Stop();
+            volumeHoldTimeoutTimer.Stop();
+            volUpPressTracker = false;
+            volDownPressTracker = false;
+        }
+
 
         /// <summary>
         /// Parses a non subscription response
@@ -331,6 +380,13 @@ namespace Pepperdash.Essentials.Plugins.DSP.Biamp.Tesira
             try
             {
                 this.LogVerbose("Parsing Message: {message} attributeCode: {attributeCode}", message, attributeCode);
+
+                if (message.IndexOf("-ERR INVALID_PARAMETER", StringComparison.Ordinal) >= 0)
+                {
+                    HandleOutOfRangeError(message);
+                    return;
+                }
+
                 // Parse an "+OK" message
 
                 var match = parseRegex.Match(message);

--- a/src/TesiraDspRoomCombiner.cs
+++ b/src/TesiraDspRoomCombiner.cs
@@ -619,8 +619,11 @@ namespace Pepperdash.Essentials.Plugins.DSP.Biamp.Tesira
                     volumeDownRepeatDelayTimer.Interval = 200;
                     volumeDownRepeatDelayTimer.Start();
                     volumeHoldTimeoutTimer.Stop();
-                    volumeHoldTimeoutTimer.Interval = VolumeHoldTimeoutMs;
-                    volumeHoldTimeoutTimer.Start();
+                    if (VolumeHoldTimeoutMs > 0)
+                    {
+                        volumeHoldTimeoutTimer.Interval = VolumeHoldTimeoutMs;
+                        volumeHoldTimeoutTimer.Start();
+                    }
                     SendFullCommand("decrement", "levelOut", IncrementAmount, 1);
                 }
 
@@ -659,8 +662,11 @@ namespace Pepperdash.Essentials.Plugins.DSP.Biamp.Tesira
                     volumeUpRepeatDelayTimer.Interval = 200;
                     volumeUpRepeatDelayTimer.Start();
                     volumeHoldTimeoutTimer.Stop();
-                    volumeHoldTimeoutTimer.Interval = VolumeHoldTimeoutMs;
-                    volumeHoldTimeoutTimer.Start();
+                    if (VolumeHoldTimeoutMs > 0)
+                    {
+                        volumeHoldTimeoutTimer.Interval = VolumeHoldTimeoutMs;
+                        volumeHoldTimeoutTimer.Start();
+                    }
                     SendFullCommand("increment", "levelOut", IncrementAmount, 1);
                     if (AutomaticUnmuteOnVolumeUp)
                     {

--- a/src/TesiraDspRoomCombiner.cs
+++ b/src/TesiraDspRoomCombiner.cs
@@ -31,6 +31,7 @@ namespace Pepperdash.Essentials.Plugins.DSP.Biamp.Tesira
             }
         }
 
+        private double rawOutVolumeLevelDb;
         private int outVolumeLevel;
         protected int OutVolumeLevel
         {
@@ -310,7 +311,24 @@ namespace Pepperdash.Essentials.Plugins.DSP.Biamp.Tesira
             if (customName != LevelCustomName) return;
             var value = double.Parse(data);
 
-            OutVolumeLevel = UseAbsoluteValue ? (ushort)value : (ushort)value.Scale(MinLevel, MaxLevel, 0, 65535, this);
+            rawOutVolumeLevelDb = value;
+
+            if (!UseAbsoluteValue && (value < MinLevel || value > MaxLevel))
+            {
+                // Value is outside our known range — the DSP range likely changed externally.
+                // Clamp to boundary so the ushort cast doesn't wrap, then re-poll to get the new range.
+                this.LogInformation(
+                    "LevelOut {val} dB outside known range [{min},{max}] — clamping feedback and re-polling min/max.",
+                    value, MinLevel, MaxLevel);
+                var clamped = Math.Max(MinLevel, Math.Min(MaxLevel, value));
+                OutVolumeLevel = (ushort)clamped.Scale(MinLevel, MaxLevel, 0, 65535, this);
+                GetMinLevel();
+                GetMaxLevel();
+            }
+            else
+            {
+                OutVolumeLevel = UseAbsoluteValue ? (ushort)value : (ushort)value.Scale(MinLevel, MaxLevel, 0, 65535, this);
+            }
 
             levelIsSubscribed = true;
 
@@ -351,10 +369,13 @@ namespace Pepperdash.Essentials.Plugins.DSP.Biamp.Tesira
 
             if (rangeChanged)
             {
+                // val is the attempted (out-of-range) level, not the actual DSP level.
+                // Clamp it to the new boundary before scaling to prevent ushort wrap.
                 var currentRaw = double.Parse(m.Groups["val"].Value);
+                var clampedRaw = Math.Max(MinLevel, Math.Min(MaxLevel, currentRaw));
                 OutVolumeLevel = UseAbsoluteValue
-                    ? (ushort)currentRaw
-                    : (ushort)currentRaw.Scale(MinLevel, MaxLevel, 0, 65535, this);
+                    ? (ushort)clampedRaw
+                    : (ushort)clampedRaw.Scale(MinLevel, MaxLevel, 0, 65535, this);
             }
 
             // Stop the repeat cycle without clearing the held flags — physical button is still down.
@@ -417,12 +438,16 @@ namespace Pepperdash.Essentials.Plugins.DSP.Biamp.Tesira
                         {
                             MinLevel = double.Parse(value);
                             this.LogDebug("MinLevel: {MinLevel}", MinLevel);
+                            if (!UseAbsoluteValue)
+                                OutVolumeLevel = (ushort)rawOutVolumeLevelDb.Scale(MinLevel, MaxLevel, 0, 65535, this);
                             break;
                         }
                     case "levelOutMax":
                         {
                             MaxLevel = double.Parse(value);
                             this.LogDebug("MaxLevel: {MaxLevel}", MaxLevel);
+                            if (!UseAbsoluteValue)
+                                OutVolumeLevel = (ushort)rawOutVolumeLevelDb.Scale(MinLevel, MaxLevel, 0, 65535, this);
                             break;
                         }
                     case "muteOut":
@@ -526,7 +551,7 @@ namespace Pepperdash.Essentials.Plugins.DSP.Biamp.Tesira
         /// </summary>
         public void GetMinLevel()
         {
-            SendFullCommand("get", "minLevel", null, 1);
+            SendFullCommand("get", "levelOutMin", null, 1);
         }
 
         /// <summary>
@@ -534,7 +559,7 @@ namespace Pepperdash.Essentials.Plugins.DSP.Biamp.Tesira
         /// </summary>
         public void GetMaxLevel()
         {
-            SendFullCommand("get", "maxLevel", null, 1);
+            SendFullCommand("get", "levelOutMax", null, 1);
         }
 
 

--- a/src/TesiraDspRoomCombiner.cs
+++ b/src/TesiraDspRoomCombiner.cs
@@ -378,13 +378,17 @@ namespace Pepperdash.Essentials.Plugins.DSP.Biamp.Tesira
                     : (ushort)clampedRaw.Scale(MinLevel, MaxLevel, 0, 65535, this);
             }
 
-            // Stop the repeat cycle without clearing the held flags — physical button is still down.
-            // Leave the hold timeout running so it remains the authoritative cleanup if release is never received.
-            this.LogDebug("Out-of-range error on {LevelControlPointTag} — stopping repeat timers and preserving hold-timeout cleanup.", LevelControlPointTag);
+            // Stop the active repeat timers and suppress any already-queued repeat-delay/repeat
+            // callbacks from re-arming the cycle by clearing the logical held state they check.
+            // Do not stop the hold-timeout timer here; the absolute maximum hold-time safeguard
+            // should remain available until the normal release/timeout cleanup path runs.
+            this.LogDebug("Out-of-range error on {LevelControlPointTag} — stopping ramp timers and suppressing held state.", LevelControlPointTag);
             volumeUpRepeatTimer.Stop();
             volumeUpRepeatDelayTimer.Stop();
             volumeDownRepeatTimer.Stop();
             volumeDownRepeatDelayTimer.Stop();
+            volUpButtonHeld = false;
+            volDownButtonHeld = false;
             volUpPressTracker = false;
             volDownPressTracker = false;
 

--- a/src/TesiraDspRoomCombiner.cs
+++ b/src/TesiraDspRoomCombiner.cs
@@ -379,13 +379,12 @@ namespace Pepperdash.Essentials.Plugins.DSP.Biamp.Tesira
             }
 
             // Stop the repeat cycle without clearing the held flags — physical button is still down.
-            // The hold timeout and the eventual button release remain the authoritative cleanup.
-            this.LogDebug("Out-of-range error on {LevelControlPointTag} — stopping ramp timers.", LevelControlPointTag);
+            // Leave the hold timeout running so it remains the authoritative cleanup if release is never received.
+            this.LogDebug("Out-of-range error on {LevelControlPointTag} — stopping repeat timers and preserving hold-timeout cleanup.", LevelControlPointTag);
             volumeUpRepeatTimer.Stop();
             volumeUpRepeatDelayTimer.Stop();
             volumeDownRepeatTimer.Stop();
             volumeDownRepeatDelayTimer.Stop();
-            volumeHoldTimeoutTimer.Stop();
             volUpPressTracker = false;
             volDownPressTracker = false;
 

--- a/src/TesiraDspRoomCombiner.cs
+++ b/src/TesiraDspRoomCombiner.cs
@@ -119,8 +119,8 @@ namespace Pepperdash.Essentials.Plugins.DSP.Biamp.Tesira
         // initial button press and cleared synchronously on release, so an in-flight
         // VolumeUpRepeatDelay/VolumeDownRepeatDelay callback can detect that the button
         // was released and bail out before re-arming the repeat cycle.
-        bool volUpButtonHeld;
-        bool volDownButtonHeld;
+        volatile bool volUpButtonHeld;
+        volatile bool volDownButtonHeld;
 
         /// <summary>
         /// Subscription identifier for Room Combiner

--- a/src/TesiraDspRoomCombiner.cs
+++ b/src/TesiraDspRoomCombiner.cs
@@ -183,7 +183,7 @@ namespace Pepperdash.Essentials.Plugins.DSP.Biamp.Tesira
             IncrementAmount = config.IncrementAmount;
             AutomaticUnmuteOnVolumeUp = config.UnmuteOnVolChange;
             VolumeRepeatRateMs = config.VolumeRepeatRateMs;
-            VolumeHoldTimeoutMs = config.VolumeHoldTimeoutMs;
+            VolumeHoldTimeoutMs = config.VolumeHoldTimeoutMs ?? 10000;
             volumeUpRepeatTimer = new System.Timers.Timer();
             volumeUpRepeatTimer.Elapsed += (sender, e) => VolumeUpRepeat();
             volumeUpRepeatTimer.AutoReset = false;


### PR DESCRIPTION
Note: I could not replicate the runaway fader condition. This release was tested against a Forte X series processor.

Fix Summary — Tesira Volume Runaway Prevention
________________________________________
Root Causes Found & How Each Was Addressed
1. System.Timers.Timer race condition (primary cause)
Timer.Stop() does not cancel a callback already dispatched to the thread pool. A thread could fire VolumeUpRepeat() after the button was released, write volUpPressTracker = true, and re-arm the timer — starting an infinite loop.

Fix: Added volUpButtonHeld / volDownButtonHeld boolean flags that are cleared synchronously on the release path (not inside a timer callback). Every repeat callback checks the held flag before re-arming. A racing callback sees false and exits cleanly.
________________________________________
2. Panel dropout — release event never delivered
If the touch panel goes offline while a button is held, the button-release join is never sent. The repeat loop runs forever because nothing calls VolumeUp(false).

Fix: The OnlineStatusChange handler now explicitly calls VolumeUp(false) and VolumeDown(false) when the trilist goes offline, forcing the same cleanup path as a normal release.
________________________________________
3. No absolute maximum hold time
Even with the above fixes, any future code path that skips the release (e.g. a new transport, a crash/restart mid-hold) would still allow indefinite ramping.

Fix: volumeHoldTimeoutTimer — a one-shot timer started when a button is first pressed. If it fires, it logs a Warning and calls VolumeUp(false) / VolumeDown(false) as a last resort. Configurable; default 10 seconds.
________________________________________
4. DSP out-of-range error during ramp — stale min/max + ushort wrap
When a DSP program constrains the fader range externally and a ramp command exceeds the (unknown) new boundary, the DSP returns -ERR INVALID_PARAMETER Value out of range: .... Previously this was unhandled; the repeat loop would keep sending commands above the max. The val in the error is the attempted value, not the actual DSP level — naively scaling it could wrap the ushort and send feedback to zero.

Fix: HandleOutOfRangeError() parses the error regex, updates MinLevel/MaxLevel from the response, clamps the raw value to the new boundary before scaling (preventing ushort wrap), fires corrected feedback, stops all ramp timers, and then sends a set command to pin the DSP exactly at the boundary.
________________________________________