### PR TITLE
test: add plugin validation test suite (44 tests)

### DIFF
--- a/Tesira-DSP-EPI.4Series.sln
+++ b/Tesira-DSP-EPI.4Series.sln
@@ -5,19 +5,50 @@ VisualStudioVersion = 17.9.34728.123
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Tesira-DSP-EPI.4Series", "src\Tesira-DSP-EPI.4Series.csproj", "{88167D44-2BA8-4F4A-A58E-CF47E1F3871F}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{0AB3BF05-4346-4AA6-1389-037BE0695223}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Tesira-DSP-EPI.Tests", "tests\Tesira-DSP-EPI.Tests.csproj", "{ED6D3301-274B-4A5E-91E5-987A85E5768C}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
 		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{88167D44-2BA8-4F4A-A58E-CF47E1F3871F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{88167D44-2BA8-4F4A-A58E-CF47E1F3871F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{88167D44-2BA8-4F4A-A58E-CF47E1F3871F}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{88167D44-2BA8-4F4A-A58E-CF47E1F3871F}.Debug|x64.Build.0 = Debug|Any CPU
+		{88167D44-2BA8-4F4A-A58E-CF47E1F3871F}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{88167D44-2BA8-4F4A-A58E-CF47E1F3871F}.Debug|x86.Build.0 = Debug|Any CPU
 		{88167D44-2BA8-4F4A-A58E-CF47E1F3871F}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{88167D44-2BA8-4F4A-A58E-CF47E1F3871F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{88167D44-2BA8-4F4A-A58E-CF47E1F3871F}.Release|x64.ActiveCfg = Release|Any CPU
+		{88167D44-2BA8-4F4A-A58E-CF47E1F3871F}.Release|x64.Build.0 = Release|Any CPU
+		{88167D44-2BA8-4F4A-A58E-CF47E1F3871F}.Release|x86.ActiveCfg = Release|Any CPU
+		{88167D44-2BA8-4F4A-A58E-CF47E1F3871F}.Release|x86.Build.0 = Release|Any CPU
+		{ED6D3301-274B-4A5E-91E5-987A85E5768C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{ED6D3301-274B-4A5E-91E5-987A85E5768C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{ED6D3301-274B-4A5E-91E5-987A85E5768C}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{ED6D3301-274B-4A5E-91E5-987A85E5768C}.Debug|x64.Build.0 = Debug|Any CPU
+		{ED6D3301-274B-4A5E-91E5-987A85E5768C}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{ED6D3301-274B-4A5E-91E5-987A85E5768C}.Debug|x86.Build.0 = Debug|Any CPU
+		{ED6D3301-274B-4A5E-91E5-987A85E5768C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{ED6D3301-274B-4A5E-91E5-987A85E5768C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{ED6D3301-274B-4A5E-91E5-987A85E5768C}.Release|x64.ActiveCfg = Release|Any CPU
+		{ED6D3301-274B-4A5E-91E5-987A85E5768C}.Release|x64.Build.0 = Release|Any CPU
+		{ED6D3301-274B-4A5E-91E5-987A85E5768C}.Release|x86.ActiveCfg = Release|Any CPU
+		{ED6D3301-274B-4A5E-91E5-987A85E5768C}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{ED6D3301-274B-4A5E-91E5-987A85E5768C} = {0AB3BF05-4346-4AA6-1389-037BE0695223}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {DE2F0231-D523-4A8D-94F6-C35589E0784F}

--- a/src/Tesira-DSP-EPI.4Series.csproj
+++ b/src/Tesira-DSP-EPI.4Series.csproj
@@ -32,7 +32,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="PepperDashEssentials" Version="3.0.0-dev-v3-routing.17">
+		<PackageReference Include="PepperDashEssentials" Version="3.0.0-dev-v3-routing.21">
 			<ExcludeAssets>runtime</ExcludeAssets>
 		</PackageReference>	</ItemGroup>
 </Project>

--- a/tests/AssemblyFixture.cs
+++ b/tests/AssemblyFixture.cs
@@ -40,7 +40,7 @@ public static class AssemblyFixture
         // Directory.GetFiles throw a less actionable DirectoryNotFoundException below.
         if (!File.Exists(PluginDllPath))
             throw new FileNotFoundException(
-                $"Plugin DLL not found at '{PluginDllPath}'. Build the plugin first.");
+                $"Plugin DLL not found at '{PluginDllPath}'. Build the plugin first.", PluginDllPath);
 
         foreach (var dll in Directory.GetFiles(PluginOutputDir, "*.dll"))
             dllByName[Path.GetFileName(dll)] = dll;
@@ -62,7 +62,7 @@ public static class AssemblyFixture
     {
         // Honor NUGET_PACKAGES (common in CI / enterprise setups); fall back to the default.
         var nugetDir = Environment.GetEnvironmentVariable("NUGET_PACKAGES");
-        if (string.IsNullOrEmpty(nugetDir))
+        if (string.IsNullOrWhiteSpace(nugetDir))
             nugetDir = Path.Combine(
                 Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
                 ".nuget", "packages");
@@ -97,7 +97,7 @@ public static class AssemblyFixture
     {
         if (!File.Exists(PluginDllPath))
             throw new FileNotFoundException(
-                $"Plugin DLL not found at '{PluginDllPath}'. Build the plugin first.");
+                $"Plugin DLL not found at '{PluginDllPath}'. Build the plugin first.", PluginDllPath);
         return Context.LoadFromAssemblyPath(PluginDllPath);
     }
 
@@ -117,9 +117,27 @@ public static class AssemblyFixture
     // Read every source file once, then search in memory - FindSourceForClass is called by many tests.
     private static readonly Lazy<string[]> AllSourceContents = new(() =>
         Directory.GetFiles(SourceDirectory, "*.cs", SearchOption.AllDirectories)
+            .Where(f => !f.Contains($"{Path.DirectorySeparatorChar}bin{Path.DirectorySeparatorChar}")
+                     && !f.Contains($"{Path.DirectorySeparatorChar}obj{Path.DirectorySeparatorChar}"))
             .Select(File.ReadAllText)
             .ToArray());
 
     public static string? FindSourceForClass(string className) =>
-        AllSourceContents.Value.FirstOrDefault(content => content.Contains($"class {className}"));
+        AllSourceContents.Value.FirstOrDefault(content => DeclaresClass(content, className));
+
+    // Match "class <name>" only when <name> ends on a non-identifier boundary, so a prefix
+    // like "Foo" does not match "class FooBar". Avoids a regex (keeps the helper allocation-light).
+    private static bool DeclaresClass(string content, string className)
+    {
+        var needle = "class " + className;
+        for (var i = content.IndexOf(needle, StringComparison.Ordinal); i >= 0;
+             i = content.IndexOf(needle, i + 1, StringComparison.Ordinal))
+        {
+            var after = i + needle.Length;
+            var next = after < content.Length ? content[after] : ' ';
+            if (!char.IsLetterOrDigit(next) && next != '_')
+                return true;
+        }
+        return false;
+    }
 }

--- a/tests/AssemblyFixture.cs
+++ b/tests/AssemblyFixture.cs
@@ -1,0 +1,118 @@
+using System.Reflection;
+using System.Text.Json;
+
+namespace Pepperdash.Essentials.Plugins.DSP.Biamp.Tesira.Tests;
+
+public static class AssemblyFixture
+{
+    private static readonly Lazy<MetadataLoadContext> LazyContext = new(CreateContext);
+    private static readonly Lazy<Assembly> LazyAssembly = new(LoadPluginAssembly);
+
+    private static string Configuration
+    {
+        get
+        {
+            var baseDir = AppContext.BaseDirectory.TrimEnd(Path.DirectorySeparatorChar);
+            var parts = baseDir.Split(Path.DirectorySeparatorChar);
+            return parts[^2]; // net8.0 is last, Configuration is second-to-last
+        }
+    }
+
+    // Nested layout: src/4Series/bin/{Config}/net8/ (OutputPath = 4Series\bin\$(Configuration)\).
+    private static string PluginDllPath =>
+        Path.GetFullPath(Path.Combine(
+            AppContext.BaseDirectory,
+            "..", "..", "..", "..",
+            "src", "4Series", "bin", Configuration, "net8",
+            "Tesira-DSP-EPI.4Series.dll"));
+
+    private static string PluginOutputDir => Path.GetDirectoryName(PluginDllPath)!;
+
+    public static MetadataLoadContext Context => LazyContext.Value;
+    public static Assembly PluginAssembly => LazyAssembly.Value;
+
+    private static MetadataLoadContext CreateContext()
+    {
+        var runtimeDir = Path.GetDirectoryName(typeof(object).Assembly.Location)!;
+        var dllByName = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var dll in Directory.GetFiles(PluginOutputDir, "*.dll"))
+            dllByName[Path.GetFileName(dll)] = dll;
+
+        foreach (var dll in Directory.GetFiles(runtimeDir, "*.dll"))
+            dllByName.TryAdd(Path.GetFileName(dll), dll);
+
+        var depsJsonPath = Path.ChangeExtension(PluginDllPath, ".deps.json");
+        if (File.Exists(depsJsonPath))
+        {
+            foreach (var path in ResolveDepsJsonAssemblies(depsJsonPath))
+                dllByName.TryAdd(Path.GetFileName(path), path);
+        }
+
+        return new MetadataLoadContext(new PathAssemblyResolver(dllByName.Values));
+    }
+
+    private static IEnumerable<string> ResolveDepsJsonAssemblies(string depsJsonPath)
+    {
+        var nugetDir = Path.Combine(
+            Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
+            ".nuget", "packages");
+
+        using var stream = File.OpenRead(depsJsonPath);
+        using var doc = JsonDocument.Parse(stream);
+
+        if (!doc.RootElement.TryGetProperty("libraries", out var libraries))
+            yield break;
+
+        foreach (var lib in libraries.EnumerateObject())
+        {
+            if (!lib.Value.TryGetProperty("type", out var typeProp) || typeProp.GetString() != "package")
+                continue;
+            if (!lib.Value.TryGetProperty("path", out var pathProp))
+                continue;
+
+            var packagePath = Path.Combine(nugetDir, pathProp.GetString()!);
+            if (!Directory.Exists(packagePath)) continue;
+
+            var libDir = Path.Combine(packagePath, "lib", "net8.0");
+            if (!Directory.Exists(libDir))
+                libDir = Path.Combine(packagePath, "lib", "netstandard2.0");
+            if (!Directory.Exists(libDir)) continue;
+
+            foreach (var dll in Directory.GetFiles(libDir, "*.dll"))
+                yield return dll;
+        }
+    }
+
+    private static Assembly LoadPluginAssembly()
+    {
+        if (!File.Exists(PluginDllPath))
+            throw new FileNotFoundException(
+                $"Plugin DLL not found at '{PluginDllPath}'. Build the plugin first.");
+        return Context.LoadFromAssemblyPath(PluginDllPath);
+    }
+
+    public static List<Type> FindFactoryTypes(string baseTypePrefix = "EssentialsPluginDeviceFactory")
+    {
+        return PluginAssembly.GetTypes()
+            .Where(t => !t.IsAbstract
+                && t.BaseType is { IsGenericType: true }
+                && t.BaseType.GetGenericTypeDefinition().Name.StartsWith(baseTypePrefix))
+            .ToList();
+    }
+
+    public static string SourceDirectory =>
+        Path.GetFullPath(Path.Combine(
+            AppContext.BaseDirectory, "..", "..", "..", "..", "src"));
+
+    public static string? FindSourceForClass(string className)
+    {
+        foreach (var file in Directory.GetFiles(SourceDirectory, "*.cs", SearchOption.AllDirectories))
+        {
+            var content = File.ReadAllText(file);
+            if (content.Contains($"class {className}"))
+                return content;
+        }
+        return null;
+    }
+}

--- a/tests/AssemblyFixture.cs
+++ b/tests/AssemblyFixture.cs
@@ -36,6 +36,12 @@ public static class AssemblyFixture
         var runtimeDir = Path.GetDirectoryName(typeof(object).Assembly.Location)!;
         var dllByName = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
 
+        // Fail clearly if the plugin hasn't been built yet, rather than letting
+        // Directory.GetFiles throw a less actionable DirectoryNotFoundException below.
+        if (!File.Exists(PluginDllPath))
+            throw new FileNotFoundException(
+                $"Plugin DLL not found at '{PluginDllPath}'. Build the plugin first.");
+
         foreach (var dll in Directory.GetFiles(PluginOutputDir, "*.dll"))
             dllByName[Path.GetFileName(dll)] = dll;
 
@@ -54,9 +60,12 @@ public static class AssemblyFixture
 
     private static IEnumerable<string> ResolveDepsJsonAssemblies(string depsJsonPath)
     {
-        var nugetDir = Path.Combine(
-            Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
-            ".nuget", "packages");
+        // Honor NUGET_PACKAGES (common in CI / enterprise setups); fall back to the default.
+        var nugetDir = Environment.GetEnvironmentVariable("NUGET_PACKAGES");
+        if (string.IsNullOrEmpty(nugetDir))
+            nugetDir = Path.Combine(
+                Environment.GetFolderPath(Environment.SpecialFolder.UserProfile),
+                ".nuget", "packages");
 
         using var stream = File.OpenRead(depsJsonPath);
         using var doc = JsonDocument.Parse(stream);
@@ -105,14 +114,12 @@ public static class AssemblyFixture
         Path.GetFullPath(Path.Combine(
             AppContext.BaseDirectory, "..", "..", "..", "..", "src"));
 
-    public static string? FindSourceForClass(string className)
-    {
-        foreach (var file in Directory.GetFiles(SourceDirectory, "*.cs", SearchOption.AllDirectories))
-        {
-            var content = File.ReadAllText(file);
-            if (content.Contains($"class {className}"))
-                return content;
-        }
-        return null;
-    }
+    // Read every source file once, then search in memory - FindSourceForClass is called by many tests.
+    private static readonly Lazy<string[]> AllSourceContents = new(() =>
+        Directory.GetFiles(SourceDirectory, "*.cs", SearchOption.AllDirectories)
+            .Select(File.ReadAllText)
+            .ToArray());
+
+    public static string? FindSourceForClass(string className) =>
+        AllSourceContents.Value.FirstOrDefault(content => content.Contains($"class {className}"));
 }

--- a/tests/ConfigDeserializationTests.cs
+++ b/tests/ConfigDeserializationTests.cs
@@ -1,0 +1,94 @@
+using FluentAssertions;
+using Xunit;
+
+namespace Pepperdash.Essentials.Plugins.DSP.Biamp.Tesira.Tests;
+
+public class ConfigDeserializationTests
+{
+    private const string Ns = "Pepperdash.Essentials.Plugins.DSP.Biamp.Tesira.";
+
+    private static readonly Lazy<Type?> ConfigType = new(() =>
+        AssemblyFixture.PluginAssembly.GetType(Ns + "TesiraDspPropertiesConfig"));
+
+    [Fact]
+    public void Config_Class_Exists()
+    {
+        ConfigType.Value.Should().NotBeNull("TesiraDspPropertiesConfig class should exist in the assembly");
+    }
+
+    [Theory]
+    [InlineData("TesiraDspPropertiesConfig")]
+    [InlineData("TesiraExpanderBlockConfig")]
+    [InlineData("TesiraFaderControlBlockConfig")]
+    [InlineData("TesiraDialerControlBlockConfig")]
+    [InlineData("TesiraSwitcherControlBlockConfig")]
+    [InlineData("TesiraRouterControlBlockConfig")]
+    [InlineData("TesiraSourceSelectorControlBlockConfig")]
+    [InlineData("TesiraStateControlBlockConfig")]
+    [InlineData("TesiraMeterBlockConfig")]
+    [InlineData("TesiraLogicMeterBlockConfig")]
+    [InlineData("TesiraCrosspointStateBlockConfig")]
+    [InlineData("TesiraRoomCombinerBlockConfig")]
+    public void Config_Block_Class_Exists_And_Is_Constructible(string className)
+    {
+        var type = AssemblyFixture.PluginAssembly.GetType(Ns + className);
+        type.Should().NotBeNull($"config class '{className}' should exist");
+        type!.GetConstructor(Type.EmptyTypes).Should()
+            .NotBeNull($"config class '{className}' must have a parameterless constructor for deserialization");
+    }
+
+    [Theory]
+    [InlineData("faderControlBlocks")]
+    [InlineData("dialerControlBlocks")]
+    [InlineData("switcherControlBlocks")]
+    [InlineData("routerControlBlocks")]
+    [InlineData("sourceSelectorControlBlocks")]
+    [InlineData("presets")]
+    [InlineData("stateControlBlocks")]
+    [InlineData("meterControlBlocks")]
+    [InlineData("logicMeterControlBlocks")]
+    [InlineData("crosspointStateControlBlocks")]
+    [InlineData("roomCombinerControlBlocks")]
+    [InlineData("tesiraExpanderBlocks")]
+    [InlineData("resubscribeString")]
+    public void Config_Property_Has_JsonPropertyAttribute(string jsonName)
+    {
+        HasJsonProperty(ConfigType.Value!, jsonName).Should()
+            .BeTrue($"TesiraDspPropertiesConfig should have a property with [JsonProperty(\"{jsonName}\")]");
+    }
+
+    [Theory]
+    [InlineData("hostname")]
+    [InlineData("index")]
+    public void ExpanderBlock_Property_Has_JsonPropertyAttribute(string jsonName)
+    {
+        var type = AssemblyFixture.PluginAssembly.GetType(Ns + "TesiraExpanderBlockConfig");
+        type.Should().NotBeNull("TesiraExpanderBlockConfig class should exist");
+        HasJsonProperty(type!, jsonName).Should()
+            .BeTrue($"TesiraExpanderBlockConfig should have a property with [JsonProperty(\"{jsonName}\")]");
+    }
+
+    [Theory]
+    [InlineData("FaderControlBlocks", "TesiraFaderControlBlockConfig")]
+    [InlineData("DialerControlBlocks", "TesiraDialerControlBlockConfig")]
+    [InlineData("ExpanderBlocks",      "TesiraExpanderBlockConfig")]
+    public void Block_Property_Is_Dictionary_Of_Expected_Value(string propertyName, string expectedValueType)
+    {
+        var prop = ConfigType.Value!.GetProperty(propertyName);
+        prop.Should().NotBeNull($"TesiraDspPropertiesConfig should expose {propertyName}");
+
+        var type = prop!.PropertyType;
+        type.IsGenericType.Should().BeTrue($"{propertyName} must be a generic dictionary");
+        type.GetGenericTypeDefinition().Name.Should().Be("Dictionary`2",
+            $"{propertyName} must be a Dictionary<string,T> so JSON objects deserialize correctly");
+        type.GetGenericArguments()[0].Name.Should().Be("String");
+        type.GetGenericArguments()[1].Name.Should().Be(expectedValueType);
+    }
+
+    private static bool HasJsonProperty(Type type, string jsonName) =>
+        type.GetProperties().Any(p =>
+            p.CustomAttributes.Any(a =>
+                a.AttributeType.Name == "JsonPropertyAttribute"
+                && a.ConstructorArguments.Any(arg =>
+                    string.Equals(arg.Value?.ToString(), jsonName, StringComparison.Ordinal))));
+}

--- a/tests/FactoryDiscoveryTests.cs
+++ b/tests/FactoryDiscoveryTests.cs
@@ -1,0 +1,41 @@
+using FluentAssertions;
+using Xunit;
+
+namespace Pepperdash.Essentials.Plugins.DSP.Biamp.Tesira.Tests;
+
+public class FactoryDiscoveryTests
+{
+    [Fact]
+    public void Assembly_Loads_Successfully()
+    {
+        AssemblyFixture.PluginAssembly.Should().NotBeNull();
+    }
+
+    [Fact]
+    public void Assembly_Name_Is_Expected()
+    {
+        AssemblyFixture.PluginAssembly.GetName().Name.Should().Be("Tesira-DSP-EPI.4Series");
+    }
+
+    [Fact]
+    public void Factory_Count_Is_One()
+    {
+        AssemblyFixture.FindFactoryTypes().Should().HaveCount(1);
+    }
+
+    [Fact]
+    public void TesiraFactory_Exists()
+    {
+        AssemblyFixture.FindFactoryTypes().Should().ContainSingle(t => t.Name == "TesiraFactory");
+    }
+
+    [Fact]
+    public void Factory_Has_Parameterless_Constructor()
+    {
+        foreach (var factory in AssemblyFixture.FindFactoryTypes())
+        {
+            factory.GetConstructor(Type.EmptyTypes).Should()
+                .NotBeNull($"Factory '{factory.Name}' must have a parameterless constructor");
+        }
+    }
+}

--- a/tests/FactoryMetadataTests.cs
+++ b/tests/FactoryMetadataTests.cs
@@ -1,0 +1,48 @@
+using System.Text.RegularExpressions;
+using FluentAssertions;
+using Xunit;
+
+namespace Pepperdash.Essentials.Plugins.DSP.Biamp.Tesira.Tests;
+
+public class FactoryMetadataTests
+{
+    private static readonly Lazy<string> FactorySource = new(() =>
+        AssemblyFixture.FindSourceForClass("TesiraFactory")
+            ?? throw new FileNotFoundException("TesiraFactory source not found"));
+
+    [Fact]
+    public void Factory_Sets_MinimumEssentialsFrameworkVersion_To_3_0_0()
+    {
+        Regex.IsMatch(FactorySource.Value, @"MinimumEssentialsFrameworkVersion\s*=\s*""3\.0\.0""")
+            .Should().BeTrue("TesiraFactory should set MinimumEssentialsFrameworkVersion to \"3.0.0\"");
+    }
+
+    [Fact]
+    public void Factory_Sets_TypeNames()
+    {
+        Regex.IsMatch(FactorySource.Value, @"TypeNames\s*=\s*new\s+List<string>")
+            .Should().BeTrue("TesiraFactory should set TypeNames in the constructor");
+    }
+
+    [Theory]
+    [InlineData("tesira")]
+    [InlineData("tesiraforte")]
+    [InlineData("tesiraserver")]
+    [InlineData("tesira-dsp")]
+    [InlineData("tesiradsp")]
+    public void Factory_Source_Contains_TypeName(string typeName)
+    {
+        FactorySource.Value.Should().Contain($"\"{typeName}\"",
+            $"TesiraFactory should register type name \"{typeName}\"");
+    }
+
+    [Fact]
+    public void No_Duplicate_TypeNames_In_Factory_Source()
+    {
+        var match = Regex.Match(FactorySource.Value, @"TypeNames\s*=\s*new\s+List<string>\s*\{([^}]+)\}");
+        match.Success.Should().BeTrue("Should find TypeNames assignment");
+
+        var quoted = Regex.Matches(match.Groups[1].Value, @"""([^""]+)""").Select(m => m.Groups[1].Value).ToList();
+        quoted.Should().OnlyHaveUniqueItems("TypeNames should not contain duplicates");
+    }
+}

--- a/tests/Tesira-DSP-EPI.Tests.csproj
+++ b/tests/Tesira-DSP-EPI.Tests.csproj
@@ -1,0 +1,27 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <IsPackable>false</IsPackable>
+    <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
+    <GenerateDocumentationFile>false</GenerateDocumentationFile>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="FluentAssertions" Version="7.0.0" />
+    <PackageReference Include="System.Reflection.MetadataLoadContext" Version="9.0.4" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <!-- Builds the plugin before tests run; DLL is loaded via MetadataLoadContext, not referenced. -->
+    <ProjectReference Include="..\src\Tesira-DSP-EPI.4Series.csproj" ReferenceOutputAssembly="false" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Adds an xUnit + MetadataLoadContext validation suite (factory discovery, factory metadata, config contracts; targeted pure-logic where applicable). All tests pass locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
**Note:** this PR also bumps `PepperDashEssentials` to `3.0.0-dev-v3-routing.21` (the version the whole Beincourt plugin set is being aligned to). The bump is required for the suite to build/run against the current Essentials; called out here per review feedback.