### PR TITLE
feat: add TesiraDspMock — hardware-free in-memory DSP stand-in for testing

### DIFF
--- a/src/Mock/TesiraDspMock.cs
+++ b/src/Mock/TesiraDspMock.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using Crestron.SimplSharp;
 using PepperDash.Core;
 using PepperDash.Core.Logging;
 using PepperDash.Essentials.Core;
@@ -49,6 +50,11 @@ namespace Pepperdash.Essentials.Plugins.DSP.Biamp.Tesira.Mock
         public Dictionary<string, IKeyName> Presets { get; }
             = new Dictionary<string, IKeyName>();
 
+        // Child faders tracked so CustomActivate() can schedule periodic feedback re-fires.
+        private readonly List<TesiraDspMockFader> _faders = new List<TesiraDspMockFader>();
+        // Held to prevent GC of the repeating timer.
+        private CTimer _feedbackRefreshTimer;
+
         public TesiraDspMock(DeviceConfig dc) : base(dc.Key, dc.Name)
         {
             var props = dc.Properties?.ToObject<TesiraDspMockPropertiesConfig>()
@@ -92,6 +98,26 @@ namespace Pepperdash.Essentials.Plugins.DSP.Biamp.Tesira.Mock
 
         // ── Setup helpers ────────────────────────────────────────────────────
 
+        public override bool CustomActivate()
+        {
+            // Re-fire all fader feedbacks on a 5-second period. This recovers from the
+            // Essentials DirectServer "new flow" race condition (Essentials 2.38.0) where
+            // PostInitialState() fires before the WebSocket transport is assigned to the
+            // UiClient. Unlike a hardware-connected DSP (which re-triggers feedbacks via
+            // subscription responses), the mock has no background polling, so this timer
+            // is the mechanism that pushes state to connecting clients after the race window.
+            _feedbackRefreshTimer = new CTimer(_ =>
+            {
+                foreach (var fader in _faders)
+                {
+                    fader.VolumeLevelFeedback.FireUpdate();
+                    fader.MuteFeedback.FireUpdate();
+                }
+            }, null, 5000, 5000);
+
+            return base.CustomActivate();
+        }
+
         private void RegisterFaders(Dictionary<string, TesiraDspMockFaderConfig> faderConfigs)
         {
             if (faderConfigs == null) return;
@@ -106,6 +132,7 @@ namespace Pepperdash.Essentials.Plugins.DSP.Biamp.Tesira.Mock
                     kvp.Value?.InitialMute ?? false);
 
                 DeviceManager.AddDevice(fader);
+                _faders.Add(fader);
             }
         }
 
@@ -119,9 +146,10 @@ namespace Pepperdash.Essentials.Plugins.DSP.Biamp.Tesira.Mock
                 var name = string.IsNullOrEmpty(cfg?.Label) ? kvp.Key : cfg.Label;
 
                 var labels = new Dictionary<string, string>();
-                if (cfg?.Sources != null)
+                var sources = cfg?.EffectiveSources;
+                if (sources != null)
                 {
-                    foreach (var s in cfg.Sources)
+                    foreach (var s in sources)
                         labels[s.Key] = string.IsNullOrEmpty(s.Value?.Label) ? s.Key : s.Value.Label;
                 }
 

--- a/src/Mock/TesiraDspMock.cs
+++ b/src/Mock/TesiraDspMock.cs
@@ -54,16 +54,16 @@ namespace Pepperdash.Essentials.Plugins.DSP.Biamp.Tesira.Mock
             var props = dc.Properties?.ToObject<TesiraDspMockPropertiesConfig>()
                         ?? new TesiraDspMockPropertiesConfig();
 
-            RegisterFaders(props.Faders);
-            RegisterSourceSelector(props.SourceSelector);
+            RegisterFaders(props.FaderControlBlocks);
+            RegisterSwitcherControlBlocks(props.SwitcherControlBlocks);
             PopulatePresets(props.Presets);
 
             this.LogInformation(
-                "TesiraDspMock '{key}' built: {faderCount} fader(s), {presetCount} preset(s), sourceSelector={hasSourceSelector}",
+                "TesiraDspMock '{key}' built: {faderCount} fader(s), {presetCount} preset(s), switcherCount={switcherCount}",
                 Key,
-                props.Faders?.Count ?? 0,
+                props.FaderControlBlocks?.Count ?? 0,
                 props.Presets?.Count ?? 0,
-                props.SourceSelector != null);
+                props.SwitcherControlBlocks?.Count ?? 0);
         }
 
         // ── IDspPresets / IHasDspPresetSave ──────────────────────────────────
@@ -109,21 +109,25 @@ namespace Pepperdash.Essentials.Plugins.DSP.Biamp.Tesira.Mock
             }
         }
 
-        private void RegisterSourceSelector(TesiraDspMockSourceSelectorConfig cfg)
+        private void RegisterSwitcherControlBlocks(Dictionary<string, TesiraDspMockSourceSelectorConfig> blocks)
         {
-            if (cfg == null || cfg.Sources == null || cfg.Sources.Count == 0) return;
-
-            var childKey = string.Format(ChildKeyFormat, Key, cfg.Key ?? "source-selector");
-            var name = string.IsNullOrEmpty(cfg.Label) ? "Source Selector" : cfg.Label;
-
-            var labels = new Dictionary<string, string>();
-            foreach (var s in cfg.Sources)
+            if (blocks == null) return;
+            foreach (var kvp in blocks)
             {
-                labels[s.Key] = string.IsNullOrEmpty(s.Value?.Label) ? s.Key : s.Value.Label;
-            }
+                var childKey = string.Format(ChildKeyFormat, Key, kvp.Key);
+                var cfg = kvp.Value;
+                var name = string.IsNullOrEmpty(cfg?.Label) ? kvp.Key : cfg.Label;
 
-            var selector = new TesiraDspMockSourceSelector(childKey, name, labels, cfg.InitialSource);
-            DeviceManager.AddDevice(selector);
+                var labels = new Dictionary<string, string>();
+                if (cfg?.Sources != null)
+                {
+                    foreach (var s in cfg.Sources)
+                        labels[s.Key] = string.IsNullOrEmpty(s.Value?.Label) ? s.Key : s.Value.Label;
+                }
+
+                var selector = new TesiraDspMockSourceSelector(childKey, name, labels, cfg?.InitialSource);
+                DeviceManager.AddDevice(selector);
+            }
         }
 
         private void PopulatePresets(Dictionary<string, TesiraDspMockPresetConfig> presetConfigs)

--- a/src/Mock/TesiraDspMock.cs
+++ b/src/Mock/TesiraDspMock.cs
@@ -1,9 +1,12 @@
 using System.Collections.Generic;
+using System.Linq;
 using Crestron.SimplSharp;
 using PepperDash.Core;
 using PepperDash.Core.Logging;
+using PepperDash.Essentials.AppServer.Messengers;
 using PepperDash.Essentials.Core;
 using PepperDash.Essentials.Core.Config;
+using PepperDash.Essentials.Core.DeviceTypeInterfaces;
 
 namespace Pepperdash.Essentials.Plugins.DSP.Biamp.Tesira.Mock
 {
@@ -57,8 +60,10 @@ namespace Pepperdash.Essentials.Plugins.DSP.Biamp.Tesira.Mock
         private readonly List<TesiraDspMockFader> _faders = new List<TesiraDspMockFader>();
         // Child source selectors tracked alongside faders for periodic state re-fire.
         private readonly List<TesiraDspMockSourceSelector> _selectors = new List<TesiraDspMockSourceSelector>();
-        // Held to prevent GC of the repeating timer.
-        private CTimer _feedbackRefreshTimer;
+        // One-shot bootstrap timer — fires both fader and selector state 5 s after
+        // activation, giving DeviceVolumeMessenger time to subscribe to OutputChange
+        // and (on RMC4) the TLS cert generation time to complete.
+        private CTimer _bootstrapTimer;
 
         public TesiraDspMock(DeviceConfig dc) : base(dc.Key, dc.Name)
         {
@@ -115,18 +120,24 @@ namespace Pepperdash.Essentials.Plugins.DSP.Biamp.Tesira.Mock
             // state reaches the frontend within 2s of the cert completing and WS being assigned.
             CommunicationMonitor.Start();
 
-            _feedbackRefreshTimer = new CTimer(_ =>
+            // One-shot bootstrap timer — fires all fader (volume + mute) and selector
+            // state 5 s after activation.  The delay serves two purposes:
+            //   1. Guarantees DeviceVolumeMessenger has run RegisterActions() and
+            //      subscribed to OutputChange before the first push (activation ordering
+            //      adds messengers to DeviceManager after faders, so they activate last).
+            //   2. On RMC4 bench setups with an empty serverCertificateFile, TLS cert
+            //      generation can take ~5 s; this ensures the WebSocket transport exists
+            //      before state is broadcast.
+            // Faders use ForcePublishState() which resets IntFeedback's internal
+            // change-tracking field so the push fires even if no value has changed
+            // since construction.  Selectors call FireUpdate() which is unconditional.
+            _bootstrapTimer = new CTimer(_ =>
             {
                 foreach (var fader in _faders)
-                {
-                    fader.VolumeLevelFeedback.FireUpdate();
-                    fader.MuteFeedback.FireUpdate();
-                }
+                    fader.ForcePublishState();
                 foreach (var selector in _selectors)
-                {
                     selector.FireUpdate();
-                }
-            }, null, 2000, 2000);
+            }, null, 5000);
 
             return base.CustomActivate();
         }
@@ -189,6 +200,25 @@ namespace Pepperdash.Essentials.Plugins.DSP.Biamp.Tesira.Mock
             public string Key { get; }
             public string Name { get; }
             public MockPreset(string key, string name) { Key = key; Name = name; }
+        }
+
+        /// <summary>
+        /// Registers the mock DSP device with Mobile Control so it appears in
+        /// <c>/devlist</c> and broadcasts its <see cref="ICommunicationMonitor"/> state.
+        /// Child devices (faders, source selector) are auto-registered separately
+        /// because they expose <c>IBasicVolumeWithFeedback</c> / <c>IHasInputs&lt;T&gt;</c>.
+        /// </summary>
+        protected override void CreateMobileControlMessengers()
+        {
+            var mc = DeviceManager.AllDevices.OfType<IMobileControl>().FirstOrDefault();
+            if (mc == null)
+            {
+                this.LogInformation("Mobile Control not found — skipping TesiraDspMock messenger registration");
+                return;
+            }
+
+            mc.AddDeviceMessenger(new ICommunicationMonitorMessenger($"{Key}-commMonitor", $"/device/{Key}", this));
+            base.CreateMobileControlMessengers();
         }
 
         // ── Communication monitor — always online (no real hardware) ─────────

--- a/src/Mock/TesiraDspMock.cs
+++ b/src/Mock/TesiraDspMock.cs
@@ -1,0 +1,148 @@
+using System.Collections.Generic;
+using PepperDash.Core;
+using PepperDash.Core.Logging;
+using PepperDash.Essentials.Core;
+using PepperDash.Essentials.Core.Config;
+
+namespace Pepperdash.Essentials.Plugins.DSP.Biamp.Tesira.Mock
+{
+    /// <summary>
+    /// Factory for <see cref="TesiraDspMock"/>. Registered under the type name
+    /// <c>tesiradspmock</c> so consumers can swap the real Tesira EPI for the mock by
+    /// changing only the config <c>type</c> field.
+    /// </summary>
+    public class TesiraDspMockFactory : EssentialsPluginDeviceFactory<TesiraDspMock>
+    {
+        public TesiraDspMockFactory()
+        {
+            MinimumEssentialsFrameworkVersion = "2.38.0";
+            TypeNames = new List<string> { "tesiradspmock" };
+        }
+
+        public override EssentialsDevice BuildDevice(DeviceConfig dc)
+        {
+            Debug.LogDebug("Factory building TesiraDspMock '{key}'", dc.Key);
+            return new TesiraDspMock(dc);
+        }
+    }
+
+    /// <summary>
+    /// Standalone in-memory stand-in for <see cref="TesiraDsp"/>. Implements the
+    /// contracts a Mobile-Control room-plugin cares about — level/mute per fader,
+    /// selectable inputs on the source selector, and DSP presets (recall + save) —
+    /// with zero hardware, zero comm, zero subscription machinery.
+    /// </summary>
+    /// <remarks>
+    /// Wire up like a real Tesira EPI, but with <c>type: "tesiradspmock"</c>. Child
+    /// device keys follow the same <c>{parentKey}--{childKey}</c> convention as the
+    /// real EPI, so room-plugin configs that reference child fader / source-selector
+    /// keys are drop-in — only the parent DSP device swaps.
+    ///
+    /// Intended for bench-testing frontend/backend round-trips when no physical DSP
+    /// is available. Not for production use.
+    /// </remarks>
+    public class TesiraDspMock : EssentialsDevice, IHasDspPresetSave
+    {
+        private const string ChildKeyFormat = "{0}--{1}";
+
+        // IHasDspPresetSave -> IDspPresets requires a Presets dictionary; populated at ctor.
+        public Dictionary<string, IKeyName> Presets { get; }
+            = new Dictionary<string, IKeyName>();
+
+        public TesiraDspMock(DeviceConfig dc) : base(dc.Key, dc.Name)
+        {
+            var props = dc.Properties?.ToObject<TesiraDspMockPropertiesConfig>()
+                        ?? new TesiraDspMockPropertiesConfig();
+
+            RegisterFaders(props.Faders);
+            RegisterSourceSelector(props.SourceSelector);
+            PopulatePresets(props.Presets);
+
+            this.LogInformation(
+                "TesiraDspMock '{key}' built: {faderCount} fader(s), {presetCount} preset(s), sourceSelector={hasSourceSelector}",
+                Key,
+                props.Faders?.Count ?? 0,
+                props.Presets?.Count ?? 0,
+                props.SourceSelector != null);
+        }
+
+        // ── IDspPresets / IHasDspPresetSave ──────────────────────────────────
+
+        public void RecallPreset(string key)
+        {
+            if (!Presets.ContainsKey(key))
+            {
+                this.LogWarning("RecallPreset — unknown preset key '{presetKey}'", key);
+                return;
+            }
+            this.LogInformation("RecallPreset (mock) — key '{presetKey}'", key);
+            // No-op: mock has no hardware to route.
+        }
+
+        public void SavePreset(string key)
+        {
+            if (!Presets.ContainsKey(key))
+            {
+                this.LogWarning("SavePreset — unknown preset key '{presetKey}'", key);
+                return;
+            }
+            this.LogInformation("SavePreset (mock) — key '{presetKey}'", key);
+            // No-op: mock has no hardware state to persist.
+        }
+
+        // ── Setup helpers ────────────────────────────────────────────────────
+
+        private void RegisterFaders(Dictionary<string, TesiraDspMockFaderConfig> faderConfigs)
+        {
+            if (faderConfigs == null) return;
+            foreach (var kvp in faderConfigs)
+            {
+                var childKey = string.Format(ChildKeyFormat, Key, kvp.Key);
+                var name = string.IsNullOrEmpty(kvp.Value?.Label) ? kvp.Key : kvp.Value.Label;
+                var fader = new TesiraDspMockFader(
+                    childKey,
+                    name,
+                    kvp.Value?.InitialLevelPercent ?? 50,
+                    kvp.Value?.InitialMute ?? false);
+
+                DeviceManager.AddDevice(fader);
+            }
+        }
+
+        private void RegisterSourceSelector(TesiraDspMockSourceSelectorConfig cfg)
+        {
+            if (cfg == null || cfg.Sources == null || cfg.Sources.Count == 0) return;
+
+            var childKey = string.Format(ChildKeyFormat, Key, cfg.Key ?? "source-selector");
+            var name = string.IsNullOrEmpty(cfg.Label) ? "Source Selector" : cfg.Label;
+
+            var labels = new Dictionary<string, string>();
+            foreach (var s in cfg.Sources)
+            {
+                labels[s.Key] = string.IsNullOrEmpty(s.Value?.Label) ? s.Key : s.Value.Label;
+            }
+
+            var selector = new TesiraDspMockSourceSelector(childKey, name, labels, cfg.InitialSource);
+            DeviceManager.AddDevice(selector);
+        }
+
+        private void PopulatePresets(Dictionary<string, TesiraDspMockPresetConfig> presetConfigs)
+        {
+            if (presetConfigs == null) return;
+            foreach (var kvp in presetConfigs)
+            {
+                var name = string.IsNullOrEmpty(kvp.Value?.Label) ? kvp.Key : kvp.Value.Label;
+                Presets[kvp.Key] = new MockPreset(kvp.Key, name);
+            }
+        }
+
+        // ── Preset entry (IKeyName is all that IDspPresets.Presets requires) ─
+
+        private sealed class MockPreset : IKeyName
+        {
+            public string Key { get; }
+            public string Name { get; }
+            public MockPreset(string key, string name) { Key = key; Name = name; }
+        }
+    }
+}

--- a/src/Mock/TesiraDspMock.cs
+++ b/src/Mock/TesiraDspMock.cs
@@ -121,7 +121,7 @@ namespace Pepperdash.Essentials.Plugins.DSP.Biamp.Tesira.Mock
             CommunicationMonitor.Start();
 
             // One-shot bootstrap timer — fires all fader (volume + mute) and selector
-            // state 5 s after activation.  The delay serves two purposes:
+            // state 5 s after activation. The delay serves two purposes:
             //   1. Guarantees DeviceVolumeMessenger has run RegisterActions() and
             //      subscribed to OutputChange before the first push (activation ordering
             //      adds messengers to DeviceManager after faders, so they activate last).
@@ -139,7 +139,25 @@ namespace Pepperdash.Essentials.Plugins.DSP.Biamp.Tesira.Mock
                     selector.FireUpdate();
             }, null, 5000);
 
+            // AlwaysOnMonitor sets Status = IsOk in its constructor, which fires
+            // StatusChange before the ICommunicationMonitorMessenger actually subscribes.
+            // That subscription doesn't happen at messenger-construction time — it happens
+            // later, in MobileControlSystemController.Initialize(), which itself only runs
+            // in response to DeviceManager.AllDevicesActivated, dispatched via Task.Run
+            // (i.e. asynchronously, with no fixed delay). A hardcoded CTimer delay raced
+            // this on real hardware with many devices/plugins. Hook the deterministic
+            // DeviceManager.AllDevicesInitialized signal instead — it only fires after
+            // every EssentialsDevice's Initialize() (including MobileControlSystemController's,
+            // which performs the actual messenger registration) has completed.
+            DeviceManager.AllDevicesInitialized += OnAllDevicesInitializedRefreshOnlineStatus;
+
             return base.CustomActivate();
+        }
+
+        private void OnAllDevicesInitializedRefreshOnlineStatus(object sender, System.EventArgs args)
+        {
+            DeviceManager.AllDevicesInitialized -= OnAllDevicesInitializedRefreshOnlineStatus;
+            ((AlwaysOnMonitor)CommunicationMonitor).Refresh();
         }
 
         private void RegisterFaders(Dictionary<string, TesiraDspMockFaderConfig> faderConfigs)
@@ -241,6 +259,18 @@ namespace Pepperdash.Essentials.Plugins.DSP.Biamp.Tesira.Mock
 
             public override void Start() { /* no-op — no poll needed */ }
             public override void Stop()  { /* no-op — no poll needed */ }
+
+            /// <summary>
+            /// Force a fresh StatusChange event even though the value never actually
+            /// changes. The Status setter is a no-op when the new value equals the
+            /// current value, so a real transition is required to get a second event
+            /// out — flip to StatusUnknown then immediately back to IsOk.
+            /// </summary>
+            public void Refresh()
+            {
+                Status = MonitorStatus.StatusUnknown;
+                Status = MonitorStatus.IsOk;
+            }
         }
     }
 }

--- a/src/Mock/TesiraDspMock.cs
+++ b/src/Mock/TesiraDspMock.cs
@@ -42,7 +42,7 @@ namespace Pepperdash.Essentials.Plugins.DSP.Biamp.Tesira.Mock
     /// Intended for bench-testing frontend/backend round-trips when no physical DSP
     /// is available. Not for production use.
     /// </remarks>
-    public class TesiraDspMock : EssentialsDevice, IHasDspPresetSave
+    public class TesiraDspMock : EssentialsDevice, IHasDspPresetSave, ICommunicationMonitor
     {
         private const string ChildKeyFormat = "{0}--{1}";
 
@@ -50,8 +50,13 @@ namespace Pepperdash.Essentials.Plugins.DSP.Biamp.Tesira.Mock
         public Dictionary<string, IKeyName> Presets { get; }
             = new Dictionary<string, IKeyName>();
 
+        // ICommunicationMonitor — always-online since the mock has no real hardware.
+        public StatusMonitorBase CommunicationMonitor { get; private set; }
+
         // Child faders tracked so CustomActivate() can schedule periodic feedback re-fires.
         private readonly List<TesiraDspMockFader> _faders = new List<TesiraDspMockFader>();
+        // Child source selectors tracked alongside faders for periodic state re-fire.
+        private readonly List<TesiraDspMockSourceSelector> _selectors = new List<TesiraDspMockSourceSelector>();
         // Held to prevent GC of the repeating timer.
         private CTimer _feedbackRefreshTimer;
 
@@ -63,6 +68,8 @@ namespace Pepperdash.Essentials.Plugins.DSP.Biamp.Tesira.Mock
             RegisterFaders(props.FaderControlBlocks);
             RegisterSwitcherControlBlocks(props.SwitcherControlBlocks);
             PopulatePresets(props.Presets);
+
+            CommunicationMonitor = new AlwaysOnMonitor(this);
 
             this.LogInformation(
                 "TesiraDspMock '{key}' built: {faderCount} fader(s), {presetCount} preset(s), switcherCount={switcherCount}",
@@ -106,12 +113,18 @@ namespace Pepperdash.Essentials.Plugins.DSP.Biamp.Tesira.Mock
             // On RMC4 bench setups with empty serverCertificateFile, TLS cert generation can
             // take ~5s, keeping the WebSocket null for that entire window. A 2s period ensures
             // state reaches the frontend within 2s of the cert completing and WS being assigned.
+            CommunicationMonitor.Start();
+
             _feedbackRefreshTimer = new CTimer(_ =>
             {
                 foreach (var fader in _faders)
                 {
                     fader.VolumeLevelFeedback.FireUpdate();
                     fader.MuteFeedback.FireUpdate();
+                }
+                foreach (var selector in _selectors)
+                {
+                    selector.FireUpdate();
                 }
             }, null, 2000, 2000);
 
@@ -155,6 +168,7 @@ namespace Pepperdash.Essentials.Plugins.DSP.Biamp.Tesira.Mock
 
                 var selector = new TesiraDspMockSourceSelector(childKey, name, labels, cfg?.InitialSource);
                 DeviceManager.AddDevice(selector);
+                _selectors.Add(selector);
             }
         }
 
@@ -175,6 +189,28 @@ namespace Pepperdash.Essentials.Plugins.DSP.Biamp.Tesira.Mock
             public string Key { get; }
             public string Name { get; }
             public MockPreset(string key, string name) { Key = key; Name = name; }
+        }
+
+        // ── Communication monitor — always online (no real hardware) ─────────
+
+        /// <summary>
+        /// Minimal <see cref="StatusMonitorBase"/> implementation that permanently
+        /// reports <see cref="MonitorStatus.IsOk"/>. The mock has no comm port to
+        /// poll, so there is nothing to monitor — it is always "online".
+        /// </summary>
+        private sealed class AlwaysOnMonitor : StatusMonitorBase
+        {
+            public AlwaysOnMonitor(IKeyed parent)
+                // StatusMonitorBase requires warningTime < errorTime and both >= 5000 ms.
+                // Values are never used because Start/Stop are no-ops.
+                : base(parent, 5000, 10000)
+            {
+                // Drive status to IsOk immediately so IsOnlineFeedback is true.
+                Status = MonitorStatus.IsOk;
+            }
+
+            public override void Start() { /* no-op — no poll needed */ }
+            public override void Stop()  { /* no-op — no poll needed */ }
         }
     }
 }

--- a/src/Mock/TesiraDspMock.cs
+++ b/src/Mock/TesiraDspMock.cs
@@ -100,12 +100,12 @@ namespace Pepperdash.Essentials.Plugins.DSP.Biamp.Tesira.Mock
 
         public override bool CustomActivate()
         {
-            // Re-fire all fader feedbacks on a 5-second period. This recovers from the
-            // Essentials DirectServer "new flow" race condition (Essentials 2.38.0) where
-            // PostInitialState() fires before the WebSocket transport is assigned to the
-            // UiClient. Unlike a hardware-connected DSP (which re-triggers feedbacks via
-            // subscription responses), the mock has no background polling, so this timer
-            // is the mechanism that pushes state to connecting clients after the race window.
+            // Re-fire all fader feedbacks every 2 seconds.
+            // Recovers from Essentials DirectServer race condition where PostInitialState()
+            // fires before the WebSocket transport is assigned on the new-flow client connect.
+            // On RMC4 bench setups with empty serverCertificateFile, TLS cert generation can
+            // take ~5s, keeping the WebSocket null for that entire window. A 2s period ensures
+            // state reaches the frontend within 2s of the cert completing and WS being assigned.
             _feedbackRefreshTimer = new CTimer(_ =>
             {
                 foreach (var fader in _faders)
@@ -113,7 +113,7 @@ namespace Pepperdash.Essentials.Plugins.DSP.Biamp.Tesira.Mock
                     fader.VolumeLevelFeedback.FireUpdate();
                     fader.MuteFeedback.FireUpdate();
                 }
-            }, null, 5000, 5000);
+            }, null, 2000, 2000);
 
             return base.CustomActivate();
         }

--- a/src/Mock/TesiraDspMock.cs
+++ b/src/Mock/TesiraDspMock.cs
@@ -112,12 +112,7 @@ namespace Pepperdash.Essentials.Plugins.DSP.Biamp.Tesira.Mock
 
         public override bool CustomActivate()
         {
-            // Re-fire all fader feedbacks every 2 seconds.
-            // Recovers from Essentials DirectServer race condition where PostInitialState()
-            // fires before the WebSocket transport is assigned on the new-flow client connect.
-            // On RMC4 bench setups with empty serverCertificateFile, TLS cert generation can
-            // take ~5s, keeping the WebSocket null for that entire window. A 2s period ensures
-            // state reaches the frontend within 2s of the cert completing and WS being assigned.
+            // Start the always-online communication monitor (no polling required for the mock).
             CommunicationMonitor.Start();
 
             // One-shot bootstrap timer — fires all fader (volume + mute) and selector

--- a/src/Mock/TesiraDspMockConfig.cs
+++ b/src/Mock/TesiraDspMockConfig.cs
@@ -1,0 +1,97 @@
+using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace Pepperdash.Essentials.Plugins.DSP.Biamp.Tesira.Mock
+{
+    /// <summary>
+    /// Config properties for the <see cref="TesiraDspMock"/> device.
+    /// Deserialized from the <c>properties</c> object of a config entry with
+    /// <c>type = "tesiradspmock"</c>.
+    /// </summary>
+    /// <remarks>
+    /// Keep this shape intentionally generic — no protocol details, no hardware
+    /// concepts. The mock is a stand-in for any consumer wiring the frontend
+    /// against the standard Essentials DSP interfaces.
+    /// </remarks>
+    public class TesiraDspMockPropertiesConfig
+    {
+        /// <summary>
+        /// Preset entries exposed via <see cref="PepperDash.Essentials.Core.IDspPresets.Presets"/>.
+        /// Recall + save both no-op on the mock (they log and return success) — sufficient to
+        /// prove the frontend → messenger → interface pipeline end-to-end.
+        /// </summary>
+        [JsonProperty("presets")]
+        public Dictionary<string, TesiraDspMockPresetConfig> Presets { get; set; }
+            = new Dictionary<string, TesiraDspMockPresetConfig>();
+
+        /// <summary>
+        /// Fader entries — each becomes a child device implementing
+        /// <see cref="PepperDash.Essentials.Core.IBasicVolumeWithFeedback"/>.
+        /// Registered with key <c>{parentKey}--{faderKey}</c> to match the Tesira EPI
+        /// convention so consumers already wired for the real device can point at the mock
+        /// by changing only the parent <c>type</c>.
+        /// </summary>
+        [JsonProperty("faders")]
+        public Dictionary<string, TesiraDspMockFaderConfig> Faders { get; set; }
+            = new Dictionary<string, TesiraDspMockFaderConfig>();
+
+        /// <summary>
+        /// Optional source-selector — becomes a child device implementing
+        /// <see cref="PepperDash.Essentials.Core.DeviceTypeInterfaces.IHasInputs{T}"/> with
+        /// key <c>{parentKey}--{sourceSelectorKey}</c> (default: <c>source-selector</c>).
+        /// </summary>
+        [JsonProperty("sourceSelector")]
+        public TesiraDspMockSourceSelectorConfig SourceSelector { get; set; }
+    }
+
+    /// <summary>Preset entry (label only — mock does not hit hardware).</summary>
+    public class TesiraDspMockPresetConfig
+    {
+        [JsonProperty("label")]
+        public string Label { get; set; }
+    }
+
+    /// <summary>Fader entry with optional seed state.</summary>
+    public class TesiraDspMockFaderConfig
+    {
+        [JsonProperty("label")]
+        public string Label { get; set; }
+
+        /// <summary>Initial level as a percent 0-100. Defaults to 50.</summary>
+        [JsonProperty("initialLevelPercent")]
+        public ushort InitialLevelPercent { get; set; } = 50;
+
+        /// <summary>Initial mute state. Defaults to false.</summary>
+        [JsonProperty("initialMute")]
+        public bool InitialMute { get; set; }
+    }
+
+    /// <summary>Source-selector entry — sources are keyed and labelled generically.</summary>
+    public class TesiraDspMockSourceSelectorConfig
+    {
+        [JsonProperty("label")]
+        public string Label { get; set; }
+
+        /// <summary>
+        /// Child key appended to the parent for DeviceManager registration.
+        /// Defaults to <c>source-selector</c>.
+        /// </summary>
+        [JsonProperty("key")]
+        public string Key { get; set; } = "source-selector";
+
+        /// <summary>Initial selection (key into <see cref="Sources"/>). Optional.</summary>
+        [JsonProperty("initialSource")]
+        public string InitialSource { get; set; }
+
+        [JsonProperty("sources")]
+        public Dictionary<string, TesiraDspMockSourceConfig> Sources { get; set; }
+            = new Dictionary<string, TesiraDspMockSourceConfig>();
+    }
+
+    /// <summary>Source entry (label only).</summary>
+    public class TesiraDspMockSourceConfig
+    {
+        [JsonProperty("label")]
+        public string Label { get; set; }
+    }
+}

--- a/src/Mock/TesiraDspMockConfig.cs
+++ b/src/Mock/TesiraDspMockConfig.cs
@@ -73,13 +73,29 @@ namespace Pepperdash.Essentials.Plugins.DSP.Biamp.Tesira.Mock
         [JsonProperty("label")]
         public string Label { get; set; }
 
-        /// <summary>Initial selection (key into <see cref="Sources"/>). Optional.</summary>
+        /// <summary>Initial selection (key into <see cref="EffectiveSources"/>). Optional.</summary>
         [JsonProperty("initialSource")]
         public string InitialSource { get; set; }
 
+        /// <summary>Mock-format source list.</summary>
         [JsonProperty("sources")]
         public Dictionary<string, TesiraDspMockSourceConfig> Sources { get; set; }
-            = new Dictionary<string, TesiraDspMockSourceConfig>();
+
+        /// <summary>
+        /// Real Tesira-format input list, deserialized from <c>switcherInputs</c>.
+        /// Used as a fallback when <see cref="Sources"/> is absent, making the mock
+        /// drop-in compatible with real Tesira EPI configs without any config edits.
+        /// </summary>
+        [JsonProperty("switcherInputs")]
+        public Dictionary<string, TesiraDspMockSourceConfig> SwitcherInputs { get; set; }
+
+        /// <summary>
+        /// Resolved source list — <see cref="Sources"/> if present and non-empty,
+        /// otherwise <see cref="SwitcherInputs"/>.
+        /// </summary>
+        [JsonIgnore]
+        public Dictionary<string, TesiraDspMockSourceConfig> EffectiveSources =>
+            Sources?.Count > 0 ? Sources : SwitcherInputs;
     }
 
     /// <summary>Source entry (label only).</summary>

--- a/src/Mock/TesiraDspMockConfig.cs
+++ b/src/Mock/TesiraDspMockConfig.cs
@@ -31,17 +31,18 @@ namespace Pepperdash.Essentials.Plugins.DSP.Biamp.Tesira.Mock
         /// convention so consumers already wired for the real device can point at the mock
         /// by changing only the parent <c>type</c>.
         /// </summary>
-        [JsonProperty("faders")]
-        public Dictionary<string, TesiraDspMockFaderConfig> Faders { get; set; }
+        [JsonProperty("faderControlBlocks")]
+        public Dictionary<string, TesiraDspMockFaderConfig> FaderControlBlocks { get; set; }
             = new Dictionary<string, TesiraDspMockFaderConfig>();
 
         /// <summary>
-        /// Optional source-selector — becomes a child device implementing
-        /// <see cref="PepperDash.Essentials.Core.DeviceTypeInterfaces.IHasInputs{T}"/> with
-        /// key <c>{parentKey}--{sourceSelectorKey}</c> (default: <c>source-selector</c>).
+        /// Optional source-selector blocks — each becomes a child device implementing
+        /// <see cref="PepperDash.Essentials.Core.DeviceTypeInterfaces.IHasInputs{T}"/>.
+        /// Keyed by block key; child device registered as <c>{parentKey}--{blockKey}</c>
+        /// to match the Tesira EPI <c>switcherControlBlocks</c> naming convention.
         /// </summary>
-        [JsonProperty("sourceSelector")]
-        public TesiraDspMockSourceSelectorConfig SourceSelector { get; set; }
+        [JsonProperty("switcherControlBlocks")]
+        public Dictionary<string, TesiraDspMockSourceSelectorConfig> SwitcherControlBlocks { get; set; }
     }
 
     /// <summary>Preset entry (label only — mock does not hit hardware).</summary>
@@ -71,13 +72,6 @@ namespace Pepperdash.Essentials.Plugins.DSP.Biamp.Tesira.Mock
     {
         [JsonProperty("label")]
         public string Label { get; set; }
-
-        /// <summary>
-        /// Child key appended to the parent for DeviceManager registration.
-        /// Defaults to <c>source-selector</c>.
-        /// </summary>
-        [JsonProperty("key")]
-        public string Key { get; set; } = "source-selector";
 
         /// <summary>Initial selection (key into <see cref="Sources"/>). Optional.</summary>
         [JsonProperty("initialSource")]

--- a/src/Mock/TesiraDspMockFader.cs
+++ b/src/Mock/TesiraDspMockFader.cs
@@ -46,7 +46,7 @@ namespace Pepperdash.Essentials.Plugins.DSP.Biamp.Tesira.Mock
         {
             if (_volumeLevel == level) return;
             _volumeLevel = level;
-            this.LogVerbose("SetVolume: {level}", level);
+            this.LogDebug("SetVolume: {level}", level);
             VolumeLevelFeedback.FireUpdate();
         }
 
@@ -68,7 +68,7 @@ namespace Pepperdash.Essentials.Plugins.DSP.Biamp.Tesira.Mock
         {
             if (_isMuted) return;
             _isMuted = true;
-            this.LogVerbose("MuteOn");
+            this.LogDebug("MuteOn");
             MuteFeedback.FireUpdate();
         }
 
@@ -76,7 +76,7 @@ namespace Pepperdash.Essentials.Plugins.DSP.Biamp.Tesira.Mock
         {
             if (!_isMuted) return;
             _isMuted = false;
-            this.LogVerbose("MuteOff");
+            this.LogDebug("MuteOff");
             MuteFeedback.FireUpdate();
         }
 

--- a/src/Mock/TesiraDspMockFader.cs
+++ b/src/Mock/TesiraDspMockFader.cs
@@ -1,0 +1,101 @@
+using PepperDash.Core.Logging;
+using PepperDash.Essentials.Core;
+
+namespace Pepperdash.Essentials.Plugins.DSP.Biamp.Tesira.Mock
+{
+    /// <summary>
+    /// In-memory fader — implements <see cref="IBasicVolumeWithFeedback"/> with no
+    /// hardware. Stores level (0–65535) and mute state, and fires the standard
+    /// Essentials feedbacks on every change so the standard auto-messengers
+    /// propagate state to consumers (e.g. React frontend hooks).
+    /// </summary>
+    public class TesiraDspMockFader : EssentialsDevice, IBasicVolumeWithFeedback
+    {
+        // Essentials volume is a ushort 0-65535. Callers on the config side supply
+        // an initial percent (0-100) which we scale up once at construction.
+        private const ushort MaxRawLevel = 65535;
+        private const ushort VolumeStep  = 655; // ~1% per press for VolumeUp/Down
+        private const ushort DefaultMuteToggleLevel = 0;
+
+        private ushort _volumeLevel;
+        private bool _isMuted;
+
+        public IntFeedback VolumeLevelFeedback { get; }
+        public BoolFeedback MuteFeedback { get; }
+
+        public TesiraDspMockFader(string key, string name, ushort initialLevelPercent, bool initialMute)
+            : base(key, name)
+        {
+            _volumeLevel = PercentToRaw(initialLevelPercent);
+            _isMuted = initialMute;
+
+            VolumeLevelFeedback = new IntFeedback(key + "-VolumeLevel", () => _volumeLevel);
+            MuteFeedback        = new BoolFeedback(key + "-Mute",         () => _isMuted);
+        }
+
+        public override bool CustomActivate()
+        {
+            // Fire initial feedback so any consumer that subscribes at activation
+            // sees the seeded state without needing to poke a control first.
+            VolumeLevelFeedback.FireUpdate();
+            MuteFeedback.FireUpdate();
+            return base.CustomActivate();
+        }
+
+        public void SetVolume(ushort level)
+        {
+            if (_volumeLevel == level) return;
+            _volumeLevel = level;
+            this.LogVerbose("SetVolume: {level}", level);
+            VolumeLevelFeedback.FireUpdate();
+        }
+
+        public void VolumeUp(bool pressRelease)
+        {
+            if (!pressRelease) return;
+            var target = (ushort)System.Math.Min(_volumeLevel + VolumeStep, MaxRawLevel);
+            SetVolume(target);
+        }
+
+        public void VolumeDown(bool pressRelease)
+        {
+            if (!pressRelease) return;
+            var target = (ushort)System.Math.Max(_volumeLevel - VolumeStep, 0);
+            SetVolume(target);
+        }
+
+        public void MuteOn()
+        {
+            if (_isMuted) return;
+            _isMuted = true;
+            this.LogVerbose("MuteOn");
+            MuteFeedback.FireUpdate();
+        }
+
+        public void MuteOff()
+        {
+            if (!_isMuted) return;
+            _isMuted = false;
+            this.LogVerbose("MuteOff");
+            MuteFeedback.FireUpdate();
+        }
+
+        public void MuteToggle()
+        {
+            if (_isMuted) MuteOff(); else MuteOn();
+            // Guard: if a caller toggles from mute-on directly with no level set yet,
+            // still leave level at DefaultMuteToggleLevel so consumers see something
+            // meaningful. (Kept explicit; no behaviour change otherwise.)
+            if (!_isMuted && _volumeLevel == 0)
+            {
+                SetVolume(DefaultMuteToggleLevel);
+            }
+        }
+
+        private static ushort PercentToRaw(ushort percent)
+        {
+            if (percent >= 100) return MaxRawLevel;
+            return (ushort)(percent * MaxRawLevel / 100);
+        }
+    }
+}

--- a/src/Mock/TesiraDspMockFader.cs
+++ b/src/Mock/TesiraDspMockFader.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Reflection;
 using PepperDash.Core.Logging;
 using PepperDash.Essentials.Core;
 
@@ -20,8 +22,14 @@ namespace Pepperdash.Essentials.Plugins.DSP.Biamp.Tesira.Mock
         private ushort _volumeLevel;
         private bool _isMuted;
 
-        public IntFeedback VolumeLevelFeedback { get; }
-        public BoolFeedback MuteFeedback { get; }
+        // Typed backing fields so ForcePublishState() can call ForceFireUpdate().
+        // The public properties expose them as IntFeedback/BoolFeedback (base types)
+        // to satisfy IBasicVolumeWithFeedback without an explicit interface impl.
+        private readonly ForceFireIntFeedback  _typedVolumeFeedback;
+        private readonly ForceFireBoolFeedback _typedMuteFeedback;
+
+        public IntFeedback  VolumeLevelFeedback { get; }
+        public BoolFeedback MuteFeedback        { get; }
 
         public TesiraDspMockFader(string key, string name, ushort initialLevelPercent, bool initialMute)
             : base(key, name)
@@ -29,17 +37,33 @@ namespace Pepperdash.Essentials.Plugins.DSP.Biamp.Tesira.Mock
             _volumeLevel = PercentToRaw(initialLevelPercent);
             _isMuted = initialMute;
 
-            VolumeLevelFeedback = new IntFeedback(key + "-VolumeLevel", () => _volumeLevel);
-            MuteFeedback        = new BoolFeedback(key + "-Mute",         () => _isMuted);
+            _typedVolumeFeedback = new ForceFireIntFeedback(key + "-VolumeLevel", () => _volumeLevel);
+            _typedMuteFeedback   = new ForceFireBoolFeedback(key + "-Mute",       () => _isMuted);
+
+            // Assign base-typed properties so the interface contract is satisfied.
+            VolumeLevelFeedback = _typedVolumeFeedback;
+            MuteFeedback        = _typedMuteFeedback;
         }
 
         public override bool CustomActivate()
         {
-            // Fire initial feedback so any consumer that subscribes at activation
-            // sees the seeded state without needing to poke a control first.
-            VolumeLevelFeedback.FireUpdate();
-            MuteFeedback.FireUpdate();
+            // Do NOT fire feedbacks here. Leaving IntFeedback._IntValue at 0 means
+            // the first ForcePublishState() call from TesiraDspMock's bootstrap timer
+            // sees a real change (0 → actual value) and pushes state to subscribers.
             return base.CustomActivate();
+        }
+
+        /// <summary>
+        /// Unconditionally broadcasts the current volume level and mute state to all
+        /// subscribed WebSocket clients, regardless of whether the values have changed
+        /// since the last push. Called by <see cref="TesiraDspMock"/>'s bootstrap
+        /// timer so newly-connecting frontends receive state without needing to
+        /// request <c>/fullStatus</c>.
+        /// </summary>
+        public void ForcePublishState()
+        {
+            _typedVolumeFeedback.ForceFireUpdate();
+            _typedMuteFeedback.ForceFireUpdate();
         }
 
         public void SetVolume(ushort level)
@@ -96,6 +120,61 @@ namespace Pepperdash.Essentials.Plugins.DSP.Biamp.Tesira.Mock
         {
             if (percent >= 100) return MaxRawLevel;
             return (ushort)(percent * MaxRawLevel / 100);
+        }
+
+        // ── Force-fire feedback helpers ──────────────────────────────────────
+        //
+        // IntFeedback.FireUpdate() and BoolFeedback.FireUpdate() only invoke
+        // OutputChange when the value has changed since the last call, which means
+        // a repeating timer that re-fires the same stored value is a no-op.
+        // These subclasses reset the internal change-tracking field to a sentinel
+        // before calling FireUpdate(), guaranteeing OutputChange fires every time
+        // ForceFireUpdate() is called regardless of current value.
+
+        private sealed class ForceFireIntFeedback : IntFeedback
+        {
+            // Cache the FieldInfo once per type. The private _IntValue field lives
+            // on IntFeedback itself, so we target that declaring type explicitly.
+            private static readonly FieldInfo s_field =
+                typeof(IntFeedback).GetField(
+                    "_IntValue",
+                    BindingFlags.NonPublic | BindingFlags.Instance);
+
+            public ForceFireIntFeedback(string key, Func<int> valueFunc)
+                : base(key, valueFunc) { }
+
+            /// <summary>
+            /// Forces OutputChange to fire with the current value even if unchanged.
+            /// Uses int.MaxValue as sentinel — outside the valid ushort range (0–65535),
+            /// so ValueFunc() can never equal it.
+            /// </summary>
+            public void ForceFireUpdate()
+            {
+                s_field?.SetValue(this, int.MaxValue);
+                FireUpdate();
+            }
+        }
+
+        private sealed class ForceFireBoolFeedback : BoolFeedback
+        {
+            private static readonly FieldInfo s_field =
+                typeof(BoolFeedback).GetField(
+                    "_BoolValue",
+                    BindingFlags.NonPublic | BindingFlags.Instance);
+
+            public ForceFireBoolFeedback(string key, Func<bool> valueFunc)
+                : base(key, valueFunc) { }
+
+            /// <summary>
+            /// Forces OutputChange to fire with the current mute value even if unchanged.
+            /// Flips the tracking field to the opposite bool, then FireUpdate() detects
+            /// a change back to the actual value.
+            /// </summary>
+            public void ForceFireUpdate()
+            {
+                s_field?.SetValue(this, !BoolValue);
+                FireUpdate();
+            }
         }
     }
 }

--- a/src/Mock/TesiraDspMockFader.cs
+++ b/src/Mock/TesiraDspMockFader.cs
@@ -150,7 +150,8 @@ namespace Pepperdash.Essentials.Plugins.DSP.Biamp.Tesira.Mock
             /// </summary>
             public void ForceFireUpdate()
             {
-                s_field?.SetValue(this, int.MaxValue);
+                if (s_field == null) throw new MissingFieldException(typeof(IntFeedback).FullName, "_IntValue");
+                s_field.SetValue(this, int.MaxValue);
                 FireUpdate();
             }
         }

--- a/src/Mock/TesiraDspMockSourceSelector.cs
+++ b/src/Mock/TesiraDspMockSourceSelector.cs
@@ -85,6 +85,15 @@ namespace Pepperdash.Essentials.Plugins.DSP.Biamp.Tesira.Mock
                     CurrentItemChanged?.Invoke(this, EventArgs.Empty);
                 }
             }
+
+            /// <summary>
+            /// Forces <see cref="ItemsUpdated"/> to fire so any subscribed auto-messenger
+            /// re-sends the full source-selector state over WebSocket.
+            /// </summary>
+            public void FireUpdate()
+            {
+                ItemsUpdated?.Invoke(this, EventArgs.Empty);
+            }
         }
 
         private sealed class MockSource : ISelectableItem
@@ -137,6 +146,20 @@ namespace Pepperdash.Essentials.Plugins.DSP.Biamp.Tesira.Mock
             {
                 IsSelected = selected;
             }
+        }
+
+        /// <summary>
+        /// Re-raises <see cref="ISelectableItems{TKey,TValue}.ItemsUpdated"/> so the Essentials
+        /// auto-messenger re-sends the full source-selector state over WebSocket.
+        ///
+        /// Called by <see cref="TesiraDspMock"/>'s periodic refresh timer to recover from the
+        /// DirectServer race condition where <c>PostInitialState()</c> fires before the WebSocket
+        /// transport is assigned on RMC4 (TLS cert generation can take ~5 s on first boot).
+        /// </summary>
+        public void FireUpdate()
+        {
+            if (Inputs is MockSourceInputs inner)
+                inner.FireUpdate();
         }
     }
 }

--- a/src/Mock/TesiraDspMockSourceSelector.cs
+++ b/src/Mock/TesiraDspMockSourceSelector.cs
@@ -1,0 +1,142 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using PepperDash.Core.Logging;
+using PepperDash.Essentials.Core;
+using PepperDash.Essentials.Core.DeviceTypeInterfaces;
+
+namespace Pepperdash.Essentials.Plugins.DSP.Biamp.Tesira.Mock
+{
+    /// <summary>
+    /// In-memory source selector — implements <see cref="IHasInputs{T}"/> keyed by string.
+    /// Exposes a collection of <see cref="ISelectableItem"/> that consumers (e.g. React
+    /// <c>useIHasSelectableItems</c>) can list and select. Selecting an item flips
+    /// <see cref="ISelectableItem.IsSelected"/> on the new + previous items and fires
+    /// <see cref="ISelectableItems{TKey,TValue}.CurrentItemChanged"/>.
+    /// </summary>
+    public class TesiraDspMockSourceSelector : EssentialsDevice, IHasInputs<string>
+    {
+        public ISelectableItems<string> Inputs { get; }
+
+        public TesiraDspMockSourceSelector(
+            string key,
+            string name,
+            IReadOnlyDictionary<string, string> sourceLabelsByKey,
+            string initialSourceKey)
+            : base(key, name)
+        {
+            var inputs = new MockSourceInputs();
+            var items = new Dictionary<string, ISelectableItem>();
+            foreach (var kvp in sourceLabelsByKey)
+            {
+                items[kvp.Key] = new MockSource(inputs, kvp.Key, kvp.Value);
+            }
+            inputs.Items = items;
+
+            if (!string.IsNullOrEmpty(initialSourceKey) && items.ContainsKey(initialSourceKey))
+            {
+                inputs.CurrentItem = initialSourceKey;
+                if (items[initialSourceKey] is MockSource seeded)
+                {
+                    seeded.SetSelectedInternal(true);
+                }
+            }
+
+            Inputs = inputs;
+        }
+
+        public override bool CustomActivate()
+        {
+            this.LogVerbose(
+                "Activated with {count} source(s): {keys}",
+                Inputs.Items.Count,
+                string.Join(", ", Inputs.Items.Keys));
+            return base.CustomActivate();
+        }
+
+        // ── inner types ──────────────────────────────────────────────────────
+
+        private sealed class MockSourceInputs : ISelectableItems<string>
+        {
+            private Dictionary<string, ISelectableItem> _items = new Dictionary<string, ISelectableItem>();
+            private string _currentItem;
+
+            public event EventHandler ItemsUpdated;
+            public event EventHandler CurrentItemChanged;
+
+            public Dictionary<string, ISelectableItem> Items
+            {
+                get { return _items; }
+                set
+                {
+                    if (_items == value) return;
+                    _items = value ?? new Dictionary<string, ISelectableItem>();
+                    ItemsUpdated?.Invoke(this, EventArgs.Empty);
+                }
+            }
+
+            public string CurrentItem
+            {
+                get { return _currentItem; }
+                set
+                {
+                    if (_currentItem == value) return;
+                    _currentItem = value;
+                    CurrentItemChanged?.Invoke(this, EventArgs.Empty);
+                }
+            }
+        }
+
+        private sealed class MockSource : ISelectableItem
+        {
+            private readonly MockSourceInputs _parent;
+            private bool _isSelected;
+
+            public event EventHandler ItemUpdated;
+
+            public string Key { get; }
+            public string Name { get; }
+
+            public bool IsSelected
+            {
+                get { return _isSelected; }
+                set
+                {
+                    if (_isSelected == value) return;
+                    _isSelected = value;
+                    ItemUpdated?.Invoke(this, EventArgs.Empty);
+                }
+            }
+
+            public MockSource(MockSourceInputs parent, string key, string name)
+            {
+                _parent = parent;
+                Key = key;
+                Name = name;
+            }
+
+            public void Select()
+            {
+                if (_parent.CurrentItem == Key) return;
+
+                // Deselect anything else that was selected — the frontend expects
+                // exactly-one-selected semantics from a source selector.
+                foreach (var pair in _parent.Items)
+                {
+                    if (pair.Value is MockSource ms && ms.Key != Key && ms.IsSelected)
+                    {
+                        ms.SetSelectedInternal(false);
+                    }
+                }
+
+                SetSelectedInternal(true);
+                _parent.CurrentItem = Key;
+            }
+
+            internal void SetSelectedInternal(bool selected)
+            {
+                IsSelected = selected;
+            }
+        }
+    }
+}

--- a/src/Mock/TesiraDspMockSourceSelector.cs
+++ b/src/Mock/TesiraDspMockSourceSelector.cs
@@ -151,7 +151,7 @@ namespace Pepperdash.Essentials.Plugins.DSP.Biamp.Tesira.Mock
         /// Re-raises <see cref="ISelectableItems{TKey,TValue}.ItemsUpdated"/> so the Essentials
         /// auto-messenger re-sends the full source-selector state over WebSocket.
         ///
-        /// Called by <see cref="TesiraDspMock"/>'s periodic refresh timer to recover from the
+        /// Called by <see cref="TesiraDspMock"/>'s bootstrap timer to recover from the
         /// DirectServer race condition where <c>PostInitialState()</c> fires before the WebSocket
         /// transport is assigned on RMC4 (TLS cert generation can take ~5 s on first boot).
         /// </summary>

--- a/src/Mock/TesiraDspMockSourceSelector.cs
+++ b/src/Mock/TesiraDspMockSourceSelector.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using PepperDash.Core.Logging;
 using PepperDash.Essentials.Core;
 using PepperDash.Essentials.Core.DeviceTypeInterfaces;

--- a/src/Mock/epi-dsp-tesira-mock_example_configurationFile_v00.01.json
+++ b/src/Mock/epi-dsp-tesira-mock_example_configurationFile_v00.01.json
@@ -24,19 +24,20 @@
                         "preset2": { "label": "Preset 2" },
                         "preset3": { "label": "Preset 3" }
                     },
-                    "faders": {
+                    "faderControlBlocks": {
                         "fader1": { "label": "Fader 1", "initialLevelPercent": 50, "initialMute": false },
                         "fader2": { "label": "Fader 2", "initialLevelPercent": 25, "initialMute": true },
                         "fader3": { "label": "Fader 3", "initialLevelPercent": 75, "initialMute": false }
                     },
-                    "sourceSelector": {
-                        "key": "source-selector",
-                        "label": "Source Selector 1",
-                        "initialSource": "source1",
-                        "sources": {
-                            "source1": { "label": "Source 1" },
-                            "source2": { "label": "Source 2" },
-                            "source3": { "label": "Source 3" }
+                    "switcherControlBlocks": {
+                        "src-selector": {
+                            "label": "Source Selector 1",
+                            "initialSource": "source1",
+                            "sources": {
+                                "source1": { "label": "Source 1" },
+                                "source2": { "label": "Source 2" },
+                                "source3": { "label": "Source 3" }
+                            }
                         }
                     }
                 }

--- a/src/Mock/epi-dsp-tesira-mock_example_configurationFile_v00.01.json
+++ b/src/Mock/epi-dsp-tesira-mock_example_configurationFile_v00.01.json
@@ -1,0 +1,46 @@
+{
+    "//": "Sample config for the TesiraDspMock — an in-memory stand-in for the real Tesira DSP EPI.",
+    "//": "Use type 'tesiradspmock' to opt in. Child device keys follow the same {parentKey}--{childKey} convention",
+    "//": "as the real Tesira EPI, so room-plugin configs that reference child fader / source-selector keys are",
+    "//": "drop-in when swapping. No comm block is required — the mock does not touch hardware.",
+    "system": {},
+    "system_url": "",
+    "template_url": "",
+    "template": {
+        "info": {
+            "comment": "Tesira DSP Mock — example",
+            "systemType": "Tesira DSP Mock",
+            "processorType": "RMC4"
+        },
+        "devices": [
+            {
+                "key": "dsp-mock-01",
+                "name": "Tesira DSP Mock",
+                "group": "dsp",
+                "type": "tesiradspmock",
+                "properties": {
+                    "presets": {
+                        "preset1": { "label": "Preset 1" },
+                        "preset2": { "label": "Preset 2" },
+                        "preset3": { "label": "Preset 3" }
+                    },
+                    "faders": {
+                        "fader1": { "label": "Fader 1", "initialLevelPercent": 50, "initialMute": false },
+                        "fader2": { "label": "Fader 2", "initialLevelPercent": 25, "initialMute": true },
+                        "fader3": { "label": "Fader 3", "initialLevelPercent": 75, "initialMute": false }
+                    },
+                    "sourceSelector": {
+                        "key": "source-selector",
+                        "label": "Source Selector 1",
+                        "initialSource": "source1",
+                        "sources": {
+                            "source1": { "label": "Source 1" },
+                            "source2": { "label": "Source 2" },
+                            "source3": { "label": "Source 3" }
+                        }
+                    }
+                }
+            }
+        ]
+    }
+}

--- a/src/Mock/epi-dsp-tesira-mock_example_configurationFile_v00.01.json
+++ b/src/Mock/epi-dsp-tesira-mock_example_configurationFile_v00.01.json
@@ -1,8 +1,10 @@
 {
-    "//": "Sample config for the TesiraDspMock — an in-memory stand-in for the real Tesira DSP EPI.",
-    "//": "Use type 'tesiradspmock' to opt in. Child device keys follow the same {parentKey}--{childKey} convention",
-    "//": "as the real Tesira EPI, so room-plugin configs that reference child fader / source-selector keys are",
-    "//": "drop-in when swapping. No comm block is required — the mock does not touch hardware.",
+    "_comment": [
+        "Sample config for the TesiraDspMock — an in-memory stand-in for the real Tesira DSP EPI.",
+        "Use type 'tesiradspmock' to opt in. Child device keys follow the same {parentKey}--{childKey} convention",
+        "as the real Tesira EPI, so room-plugin configs that reference child fader / source-selector keys are",
+        "drop-in when swapping. No comm block is required — the mock does not touch hardware."
+    ],
     "system": {},
     "system_url": "",
     "template_url": "",


### PR DESCRIPTION
## Summary

Adds `TesiraDspMock`, an in-memory stand-in for the Biamp Tesira DSP EPI that requires no physical hardware and no network/serial communication. It lets rooms and touchpanel UIs be developed, bench-tested, and demoed against realistic DSP behavior (levels, mutes, presets, source selection) when a real Tesira is unavailable.

## Why this should be merged

- **Hardware-free testing/CI:** Development and automated/bench testing currently require a physical Tesira (or a separate emulator). The mock removes that dependency entirely — no comm block, no device on the network.
- **Drop-in compatibility:** Child device keys follow the same `{parentKey}--{childKey}` convention as the real Tesira EPI, so configs that reference child fader / source-selector keys swap in and out by changing only the device `type` to `tesiradspmock`. No consumer code changes required to switch between real and mock.
- **Realistic, deterministic state:** Implements `ICommunicationMonitor` reporting always-online, deterministic online-status refresh, and forced feedback/state broadcasting so WebSocket-driven UIs receive consistent updates without a live device.
- **Additive and isolated:** All new code lives under a new `Mock/` area plus an example config. No existing EPI behavior is modified, so there is no impact on production Tesira deployments.

## What's included

- `TesiraDspMock` — in-memory device with presets, faders, and source selection; always-online status and feedback refresh.
- `TesiraDspMockFader` — mock fader block (level %, mute) with state broadcasting.
- `TesiraDspMockSourceSelector` — mock source selector with UI state refresh.
- `TesiraDspMockConfig` — configuration model for the mock's initial state.
- Example configuration demonstrating the `tesiradspmock` device type with sample presets, faders, and sources.

## Version impact

Minor release — new opt-in feature (`type: "tesiradspmock"`), fully backward compatible; no public API removed or changed.

## Validation

Builds cleanly and loads on a 4-series appliance as a device type; faders, mutes, presets, and source selection drive UI feedback with no hardware present.
